### PR TITLE
feat: vsock vtable インターフェース定義と RAW/DGRAM アダプター実装

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,15 @@ file(GLOB_RECURSE SOURCES
 
 message(STATUS "SOURCES: ${SOURCES}")
 
+add_library(testftping ${SOURCES}) 
+target_include_directories(
+  testftping
+  PRIVATE ${CMAKE_SOURCE_DIR}/cmd/ft_ping
+)
+target_compile_definitions(testftping PUBLIC TESTING=1)
+
 # add_subdirectory(lib/shared)
-# add_subdirectory(lib/vsock)
+add_subdirectory(lib/vsock)
 
 add_executable(ft_ping ${SOURCES})
 
@@ -24,8 +31,9 @@ target_include_directories(
   ft_ping
   PRIVATE ${CMAKE_SOURCE_DIR}/cmd/ft_ping
 )
-# target_link_libraries(ft_ping ${LIBRARIES})
-target_link_libraries(ft_ping PRIVATE vsock shared)
+
+target_link_libraries(ft_ping PRIVATE vsock)
+# target_link_libraries(ft_ping PRIVATE vsock shared)
 
 enable_testing()
 add_subdirectory(tests)

--- a/docs/c-vtable-pattern.md
+++ b/docs/c-vtable-pattern.md
@@ -1,0 +1,101 @@
+# C言語における vtable パターン
+
+## 概要
+
+C でオブジェクト指向的な多態性（ポリモーフィズム）を実現するパターン。
+関数ポインタを持つ構造体をインターフェースとして使い、実装ごとにグローバルインスタンスを定義する。
+
+curl の `vtls/` ディレクトリや Linux カーネルの `file_operations` が同じ構造を採用している。
+
+---
+
+## 構成要素
+
+### 1. インターフェース定義（ヘッダー）
+
+```c
+// vsock.h
+typedef struct ping_socket_ops {
+  int             (*configure)(int fd);
+  int             (*build_packet)(void *packet, uint16_t seq, size_t datalen, struct timeval *ts);
+  struct icmphdr *(*extract_icmp)(void *packet, size_t packet_len, int *icmp_len_out);
+  size_t          (*packet_size)(size_t datalen);
+} t_ping_socket_ops;
+
+// 実装インスタンスの extern 宣言
+extern t_ping_socket_ops Ping_socket_raw_ops;
+extern t_ping_socket_ops Ping_socket_dgram_ops;
+```
+
+### 2. 実装定義（各 .c ファイル）
+
+```c
+// vsock_raw.c
+static int raw_configure(int fd) {
+  int on = 1;
+  return setsockopt(fd, IPPROTO_IP, IP_HDRINCL, &on, sizeof(on));
+}
+// ...
+
+t_ping_socket_ops Ping_socket_raw_ops = {
+  .create       = raw_create,
+  .configure    = raw_configure,
+  .build_packet = raw_build_packet,
+  .extract_icmp = raw_extract_icmp,
+  .packet_size  = raw_packet_size,
+};
+```
+
+```c
+// vsock_dgram.c
+t_ping_socket_ops Ping_socket_dgram_ops = {
+  .create       = dgram_create,
+  .configure    = dgram_configure,
+  // ...
+};
+```
+
+### 3. 利用側（使う側は ops ポインタ経由で呼ぶ）
+
+```c
+// vtable を選択してセット
+ping_socket_select(&master->socket_state);
+
+// 種別を意識せず呼び出せる
+master->socket_state.ops->configure(fd);
+master->socket_state.ops->build_packet(packet, seq, datalen, &ts);
+```
+
+---
+
+## C++ との対応
+
+| C++ | C（このパターン） |
+|-----|-----------------|
+| `class` / `interface` | `typedef struct ping_socket_ops` |
+| 仮想関数テーブル (vtable) | 関数ポインタのメンバー |
+| `new RawSocket()` | `Ping_socket_raw_ops` グローバルインスタンス |
+| 派生クラスのインスタンス | `socket_state->ops = &Ping_socket_raw_ops` |
+| 仮想関数呼び出し | `socket_state->ops->configure(fd)` |
+
+---
+
+## extern 宣言の意味
+
+```c
+extern t_ping_socket_ops Ping_socket_raw_ops;
+```
+
+- `extern` は「実体は別の .c ファイルにある」という宣言
+- `Ping_socket_raw_ops` は関数ポインタのみを持ち状態を持たないため、グローバルに1つあれば十分（シングルトン相当）
+- ヘッダーに `extern` 宣言を置くことで、どのファイルからでも参照できる
+
+実体は `vsock_raw.c` の `t_ping_socket_ops Ping_socket_raw_ops = { ... }` で定義される。
+
+---
+
+## このパターンのメリット
+
+- 呼び出し側に `if (socktype == SOCK_RAW)` の分岐が不要になる
+- 実装を追加するとき（例: IPv6対応）はインスタンスを1つ追加するだけ
+- テストで差し替えが容易（モック用の ops インスタンスを渡せる）

--- a/include/ft_ping/ft_ping.h
+++ b/include/ft_ping/ft_ping.h
@@ -14,8 +14,8 @@ struct rcvd_table {
 };
 
 /* ビット操作マクロ */
-#define A(tbl, bit) ((tbl)->bitmap[(bit) >> BITMAP_SHIFT])
-#define B(bit) (((bitmap_t)1) << ((bit) & ((1 << BITMAP_SHIFT) - 1)))
+#define BITMAP_WORD(tbl, bit) ((tbl)->bitmap[(bit) >> BITMAP_SHIFT])
+#define BITMAP_MASK(bit) (((bitmap_t)1) << ((bit) & ((1 << BITMAP_SHIFT) - 1)))
 
 typedef struct ftping_session t_ftping_session; // 前方宣言
 

--- a/lib/vsock/CMakeLists.txt
+++ b/lib/vsock/CMakeLists.txt
@@ -1,0 +1,10 @@
+file(GLOB_RECURSE SOURCES
+"${CMAKE_CURRENT_SOURCE_DIR}/*.c"
+)
+
+add_library(vsock STATIC ${SOURCES})
+
+target_include_directories(
+  vsock
+  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/lib/vsock/vsock.c
+++ b/lib/vsock/vsock.c
@@ -1,0 +1,24 @@
+#include "vsock.h"
+
+// TODO: 設定されたオプションパラメータに応じてどちらのソケットで作成するか選択するように
+int ping_socket_select(t_socket_st *socket_state) {
+  socket_state->fd = -1;
+  socket_state->socktype = -1;
+
+  socket_state->fd = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP);
+  if (socket_state->fd >= 0) {
+    socket_state->socktype = SOCK_RAW;
+    socket_state->ops = &Ping_socket_raw_ops;
+    return socket_state->fd;
+  }
+  // SOCK_DGRAM で作る
+  if (errno == EPERM || errno == EACCES) {
+    socket_state->fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_ICMP);
+    if (socket_state->fd >= 0) {
+      socket_state->socktype = SOCK_DGRAM;
+      socket_state->ops = &Ping_socket_dgram_ops;
+      return socket_state->fd;
+    }
+  }
+  return -1;
+}

--- a/lib/vsock/vsock.c
+++ b/lib/vsock/vsock.c
@@ -1,5 +1,21 @@
 #include "vsock.h"
 
+uint16_t calculate_checksum(void *data, size_t len) {
+  uint32_t sum = 0;
+  uint16_t *ptr = data;
+
+  while (len > 1) {
+    sum += *ptr++;
+    len -= 2;
+  }
+  if (len == 1) {
+    sum += *(uint8_t *)ptr;
+  }
+  sum = (sum >> 16) + (sum & 0xffff);
+  sum += (sum >> 16);
+  return (uint16_t)~sum;
+}
+
 // TODO: 設定されたオプションパラメータに応じてどちらのソケットで作成するか選択するように
 int ping_socket_select(t_socket_st *socket_state) {
   socket_state->fd = -1;

--- a/lib/vsock/vsock.h
+++ b/lib/vsock/vsock.h
@@ -11,8 +11,10 @@
 #include <netinet/ip_icmp.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/socket.h>
 #include <sys/time.h>
+#include <unistd.h>
 
 typedef struct ip_icmp {
   struct iphdr ip;
@@ -45,6 +47,7 @@ typedef struct ping_socket_ops {
 extern t_ping_socket_ops Ping_socket_raw_ops;
 extern t_ping_socket_ops Ping_socket_dgram_ops;
 
+uint16_t calculate_checksum(void *data, size_t len);
 int ping_socket_select(t_socket_st *socket_state);
 
 #endif /* VSOCK_H */

--- a/lib/vsock/vsock.h
+++ b/lib/vsock/vsock.h
@@ -1,0 +1,50 @@
+#ifndef VSOCK_H
+#define VSOCK_H
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <errno.h>
+#include <limits.h>
+#include <netinet/in.h>
+#include <netinet/ip_icmp.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+
+typedef struct ip_icmp {
+  struct iphdr ip;
+  struct icmphdr icmp;
+} t_ip_icmp;
+
+typedef struct {
+  uint16_t seq;
+  size_t datalen;
+  struct timeval *ts;
+  struct in_addr src;
+  struct in_addr dst;
+} t_build_ctx;
+
+typedef struct ping_socket_ops t_ping_socket_ops;
+
+typedef struct socket_st {
+  int fd;
+  int socktype;
+  const t_ping_socket_ops *ops;
+} t_socket_st;
+
+typedef struct ping_socket_ops {
+  int (*build_packet)(void *packet, const t_build_ctx *ctx);
+  struct icmphdr *(*extract_icmp)(void *packet, size_t packet_len, int *icmp_len_out);
+  size_t (*packet_size)(size_t datalen);
+  int (*extra_configure)(int fd);
+} t_ping_socket_ops;
+
+extern t_ping_socket_ops Ping_socket_raw_ops;
+extern t_ping_socket_ops Ping_socket_dgram_ops;
+
+int ping_socket_select(t_socket_st *socket_state);
+
+#endif /* VSOCK_H */

--- a/lib/vsock/vsock_dgram.c
+++ b/lib/vsock/vsock_dgram.c
@@ -1,0 +1,41 @@
+#include "vsock.h"
+
+int build_packet_dgram(void *packet, const t_build_ctx *ctx) {
+  if (packet == NULL || ctx == NULL || ctx->datalen <= 0) {
+    return -1;
+  }
+  struct icmphdr *icmp_hdr = (struct icmphdr *)packet;
+  unsigned char *payload = (unsigned char *)packet + sizeof(struct icmphdr);
+  icmp_hdr->type = ICMP_ECHO;
+  icmp_hdr->code = 0;
+  icmp_hdr->checksum = 0;
+  icmp_hdr->un.echo.id = htons(getpid());
+  icmp_hdr->un.echo.sequence = htons(ctx->seq + 1);
+  for (size_t i = 0; i < ctx->datalen; i++) {
+    payload[i] = (unsigned char)((size_t)i % UCHAR_MAX);
+  }
+  if (ctx->datalen >= sizeof(*(ctx->ts))) {
+    memcpy(payload, ctx->ts, sizeof(*(ctx->ts)));
+  }
+  size_t packet_size = sizeof(struct icmphdr) + ctx->datalen;
+  icmp_hdr->checksum = calculate_checksum((void *)icmp_hdr, packet_size);
+  return 0;
+}
+
+int extract_icmp_dgram(void *packet, size_t packet_len, int *icmp_len_out) {
+  *icmp_len_out = packet_len;
+  return (struct icmphdr *)packet;
+}
+
+int extra_configure_dgram(int fd) {
+  (void)fd;
+  return 0;
+} // dgram ソケットでは不要
+
+size_t packet_size_dgram(size_t datalen) { return sizeof(struct icmphdr) + datalen; }
+
+t_ping_socket_ops Ping_socket_dgram_ops = {
+    .build_packet = build_packet_dgram,
+    .extract_icmp = extract_icmp_dgram,
+    .packet_size = packet_size_dgram,
+    .extra_configure = extra_configure_dgram};

--- a/lib/vsock/vsock_dgram.c
+++ b/lib/vsock/vsock_dgram.c
@@ -22,7 +22,7 @@ int build_packet_dgram(void *packet, const t_build_ctx *ctx) {
   return 0;
 }
 
-int extract_icmp_dgram(void *packet, size_t packet_len, int *icmp_len_out) {
+struct icmphdr *extract_icmp_dgram(void *packet, size_t packet_len, int *icmp_len_out) {
   *icmp_len_out = packet_len;
   return (struct icmphdr *)packet;
 }

--- a/lib/vsock/vsock_raw.c
+++ b/lib/vsock/vsock_raw.c
@@ -1,0 +1,84 @@
+#include "vsock.h"
+
+static int set_ip_header(void *packet, const t_build_ctx *ctx);
+
+int build_packet_raw(void *packet, const t_build_ctx *ctx) {
+  if (packet == NULL || ctx == NULL || ctx->datalen <= 0) {
+    return -1;
+  }
+  if (set_ip_header(packet, ctx) != 0) {
+    return -1;
+  }
+  t_ip_icmp *raw_icmp_hdr = (t_ip_icmp *)packet;
+  struct icmphdr *icmp_hdr = &raw_icmp_hdr->icmp;
+  unsigned char *payload = (unsigned char *)packet + sizeof(t_ip_icmp);
+
+  icmp_hdr->type = ICMP_ECHO;
+  icmp_hdr->code = 0;
+  icmp_hdr->checksum = 0;
+  icmp_hdr->un.echo.id = htons(getpid());
+  icmp_hdr->un.echo.sequence = htons(ctx->seq + 1);
+  for (size_t i = 0; i < ctx->datalen; i++) {
+    payload[i] = (unsigned char)((size_t)i % UCHAR_MAX);
+  }
+  if (ctx->datalen >= sizeof(*(ctx->ts))) {
+    memcpy(payload, ctx->ts, sizeof(*(ctx->ts)));
+  }
+  size_t packet_size = sizeof(struct icmphdr) + ctx->datalen;
+  icmp_hdr->checksum = calculate_checksum((void *)icmp_hdr, packet_size);
+  return 0;
+}
+
+static int set_ip_header(void *packet, const t_build_ctx *ctx) {
+  if (packet == NULL || ctx == NULL || ctx->datalen <= 0) {
+    return -1;
+  }
+  t_ip_icmp *packet_icmp = (t_ip_icmp *)packet;
+
+  packet_icmp->ip.version = 4;
+  packet_icmp->ip.ihl = 5;
+  packet_icmp->ip.tos = 0;
+  packet_icmp->ip.tot_len = htons(sizeof(t_ip_icmp) + ctx->datalen);
+  packet_icmp->ip.id = htons(getpid());
+  packet_icmp->ip.frag_off = 0;
+  packet_icmp->ip.ttl = 64;
+  packet_icmp->ip.protocol = IPPROTO_ICMP;
+  packet_icmp->ip.check = 0;
+
+  packet_icmp->ip.saddr = ctx->src.s_addr;
+  packet_icmp->ip.daddr = ctx->dst.s_addr;
+  packet_icmp->ip.check = calculate_checksum(&packet_icmp->ip, packet_icmp->ip.ihl * 4);
+  return 0;
+}
+
+struct icmphdr *extract_icmp_raw(void *packet, size_t packet_len, int *icmp_len_out) {
+  struct icmphdr *icmp;
+  struct iphdr *ip = NULL;
+  int icmp_len;
+
+  ip = (struct iphdr *)packet;
+  icmp_len = packet_len - (ip->ihl * 4);
+  if (icmp_len < 8) {
+    return NULL;
+  }
+  *icmp_len_out = icmp_len;
+  icmp = (struct icmphdr *)((char *)packet + (ip->ihl * 4));
+  return icmp;
+}
+
+int extra_configure_raw(int fd) {
+  // IP_HDRINCLオプションの設定（自前でIPヘッダを含める）: これがないとRAWソケットで送信できない
+  int hdrincl = 1;
+  if (setsockopt(fd, IPPROTO_IP, IP_HDRINCL, &hdrincl, sizeof(hdrincl)) < 0) {
+    return -1; // error(1, "setsockopt IP_HDRINCL failed: %s\n", strerror(errno));
+  }
+  return 0;
+}
+
+size_t packet_size_raw(size_t datalen) { return sizeof(t_ip_icmp) + datalen; }
+
+t_ping_socket_ops Ping_socket_raw_ops = {
+    .build_packet = build_packet_raw,
+    .extract_icmp = extract_icmp_raw,
+    .packet_size = packet_size_raw,
+    .extra_configure = extra_configure_raw};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,13 +26,14 @@ file(GLOB_RECURSE TEST_SOURCES
 add_executable(InternalTests ${TEST_SOURCES})
 
 if(GTest_FOUND)
-  target_link_libraries(InternalTests testftping GTest::GTest GTest::Main)
+  target_link_libraries(InternalTests testftping vsock GTest::GTest GTest::Main)
 else()
-  target_link_libraries(InternalTests testftping gtest gtest_main)
+  target_link_libraries(InternalTests testftping vsock gtest gtest_main)
 endif()
 
-target_include_directories(InternalTests PRIVATE 
+target_include_directories(InternalTests PRIVATE
   ${CMAKE_SOURCE_DIR}/cmd/ft_ping
+  ${CMAKE_SOURCE_DIR}/lib/vsock
   ${gtest_SOURCE_DIR}
 )
 

--- a/tests/unit/test_vsock_dgram.cpp
+++ b/tests/unit/test_vsock_dgram.cpp
@@ -1,0 +1,92 @@
+#include <gtest/gtest.h>
+#include <netinet/in.h>
+#include <sys/time.h>
+
+extern "C" {
+#include "vsock.h"
+}
+
+class VsockDgramOpsTest : public ::testing::Test {
+protected:
+  t_build_ctx make_ctx(size_t datalen) {
+    t_build_ctx ctx = {};
+    ctx.seq = 0;
+    ctx.datalen = datalen;
+    ctx.ts = &ts_;
+    gettimeofday(&ts_, NULL);
+    ctx.src.s_addr = htonl(0x7f000001);
+    ctx.dst.s_addr = htonl(0x7f000001);
+    return ctx;
+  }
+
+  struct timeval ts_;
+};
+
+TEST_F(VsockDgramOpsTest, VtablePointersAreSet) {
+  EXPECT_NE(Ping_socket_dgram_ops.build_packet, nullptr);
+  EXPECT_NE(Ping_socket_dgram_ops.extract_icmp, nullptr);
+  EXPECT_NE(Ping_socket_dgram_ops.packet_size, nullptr);
+  EXPECT_NE(Ping_socket_dgram_ops.extra_configure, nullptr);
+}
+
+// DGRAM は IP ヘッダを自分で作らないので RAW より小さい
+TEST_F(VsockDgramOpsTest, PacketSizeSmallerThanRaw) {
+  size_t datalen = 56;
+  size_t dgram_size = Ping_socket_dgram_ops.packet_size(datalen);
+  size_t raw_size = Ping_socket_raw_ops.packet_size(datalen);
+  EXPECT_EQ(dgram_size, sizeof(struct icmphdr) + datalen);
+  EXPECT_LT(dgram_size, raw_size);
+}
+
+TEST_F(VsockDgramOpsTest, BuildPacketSucceeds) {
+  size_t datalen = 56;
+  size_t pkt_size = Ping_socket_dgram_ops.packet_size(datalen);
+  void *buf = calloc(1, pkt_size);
+  ASSERT_NE(buf, nullptr);
+
+  t_build_ctx ctx = make_ctx(datalen);
+  int ret = Ping_socket_dgram_ops.build_packet(buf, &ctx);
+  EXPECT_EQ(ret, 0);
+
+  struct icmphdr *icmp = (struct icmphdr *)buf;
+  EXPECT_EQ(icmp->type, ICMP_ECHO);
+  EXPECT_EQ(icmp->code, 0);
+  free(buf);
+}
+
+TEST_F(VsockDgramOpsTest, BuildPacketFailsOnNull) {
+  t_build_ctx ctx = make_ctx(56);
+  EXPECT_EQ(Ping_socket_dgram_ops.build_packet(NULL, &ctx), -1);
+  EXPECT_EQ(Ping_socket_dgram_ops.build_packet((void *)1, NULL), -1);
+}
+
+TEST_F(VsockDgramOpsTest, ExtractIcmpReturnsPacketStart) {
+  size_t datalen = 56;
+  size_t pkt_size = Ping_socket_dgram_ops.packet_size(datalen);
+  void *buf = calloc(1, pkt_size);
+  ASSERT_NE(buf, nullptr);
+
+  t_build_ctx ctx = make_ctx(datalen);
+  Ping_socket_dgram_ops.build_packet(buf, &ctx);
+
+  int icmp_len = 0;
+  struct icmphdr *icmp = Ping_socket_dgram_ops.extract_icmp(buf, pkt_size, &icmp_len);
+  // DGRAM は IP ヘッダがないのでパケット先頭が ICMP ヘッダ
+  EXPECT_EQ((void *)icmp, buf);
+  EXPECT_EQ((size_t)icmp_len, pkt_size);
+  free(buf);
+}
+
+// DGRAM の extra_configure は何もせず 0 を返す
+TEST_F(VsockDgramOpsTest, ExtraConfigureIsNoop) {
+  int ret = Ping_socket_dgram_ops.extra_configure(0);
+  EXPECT_EQ(ret, 0);
+}
+
+// RAW と DGRAM で関数ポインタが異なること
+TEST_F(VsockDgramOpsTest, VtableDiffersFromRaw) {
+  EXPECT_NE(Ping_socket_dgram_ops.build_packet, Ping_socket_raw_ops.build_packet);
+  EXPECT_NE(Ping_socket_dgram_ops.extract_icmp, Ping_socket_raw_ops.extract_icmp);
+  EXPECT_NE(Ping_socket_dgram_ops.packet_size, Ping_socket_raw_ops.packet_size);
+  EXPECT_NE(Ping_socket_dgram_ops.extra_configure, Ping_socket_raw_ops.extra_configure);
+}

--- a/tests/unit/test_vsock_raw.cpp
+++ b/tests/unit/test_vsock_raw.cpp
@@ -1,0 +1,91 @@
+#include <gtest/gtest.h>
+#include <netinet/in.h>
+#include <sys/time.h>
+
+extern "C" {
+#include "vsock.h"
+}
+
+class VsockRawOpsTest : public ::testing::Test {
+protected:
+  t_build_ctx make_ctx(size_t datalen) {
+    t_build_ctx ctx = {};
+    ctx.seq = 0;
+    ctx.datalen = datalen;
+    ctx.ts = &ts_;
+    gettimeofday(&ts_, NULL);
+    ctx.src.s_addr = htonl(0x7f000001); // 127.0.0.1
+    ctx.dst.s_addr = htonl(0x7f000001);
+    return ctx;
+  }
+
+  struct timeval ts_;
+};
+
+TEST_F(VsockRawOpsTest, VtablePointersAreSet) {
+  EXPECT_NE(Ping_socket_raw_ops.build_packet, nullptr);
+  EXPECT_NE(Ping_socket_raw_ops.extract_icmp, nullptr);
+  EXPECT_NE(Ping_socket_raw_ops.packet_size, nullptr);
+  EXPECT_NE(Ping_socket_raw_ops.extra_configure, nullptr);
+}
+
+TEST_F(VsockRawOpsTest, PacketSizeIncludesIpHeader) {
+  size_t datalen = 56;
+  size_t size = Ping_socket_raw_ops.packet_size(datalen);
+  EXPECT_EQ(size, sizeof(t_ip_icmp) + datalen);
+}
+
+TEST_F(VsockRawOpsTest, BuildPacketSucceeds) {
+  size_t datalen = 56;
+  size_t pkt_size = Ping_socket_raw_ops.packet_size(datalen);
+  void *buf = calloc(1, pkt_size);
+  ASSERT_NE(buf, nullptr);
+
+  t_build_ctx ctx = make_ctx(datalen);
+  int ret = Ping_socket_raw_ops.build_packet(buf, &ctx);
+  EXPECT_EQ(ret, 0);
+
+  t_ip_icmp *pkt = (t_ip_icmp *)buf;
+  EXPECT_EQ(pkt->icmp.type, ICMP_ECHO);
+  EXPECT_EQ(pkt->icmp.code, 0);
+  EXPECT_EQ(pkt->ip.protocol, IPPROTO_ICMP);
+  EXPECT_EQ(ntohs(pkt->ip.tot_len), (uint16_t)(sizeof(t_ip_icmp) + datalen));
+  free(buf);
+}
+
+TEST_F(VsockRawOpsTest, BuildPacketFailsOnNull) {
+  t_build_ctx ctx = make_ctx(56);
+  EXPECT_EQ(Ping_socket_raw_ops.build_packet(NULL, &ctx), -1);
+  EXPECT_EQ(Ping_socket_raw_ops.build_packet((void *)1, NULL), -1);
+}
+
+TEST_F(VsockRawOpsTest, ExtractIcmpFromValidPacket) {
+  size_t datalen = 56;
+  size_t pkt_size = Ping_socket_raw_ops.packet_size(datalen);
+  void *buf = calloc(1, pkt_size);
+  ASSERT_NE(buf, nullptr);
+
+  t_build_ctx ctx = make_ctx(datalen);
+  Ping_socket_raw_ops.build_packet(buf, &ctx);
+
+  int icmp_len = 0;
+  struct icmphdr *icmp = Ping_socket_raw_ops.extract_icmp(buf, pkt_size, &icmp_len);
+  ASSERT_NE(icmp, nullptr);
+  EXPECT_EQ(icmp->type, ICMP_ECHO);
+  EXPECT_GT(icmp_len, 0);
+  free(buf);
+}
+
+TEST_F(VsockRawOpsTest, ChecksumIsNonZeroAfterBuild) {
+  size_t datalen = 56;
+  size_t pkt_size = Ping_socket_raw_ops.packet_size(datalen);
+  void *buf = calloc(1, pkt_size);
+  ASSERT_NE(buf, nullptr);
+
+  t_build_ctx ctx = make_ctx(datalen);
+  Ping_socket_raw_ops.build_packet(buf, &ctx);
+
+  t_ip_icmp *pkt = (t_ip_icmp *)buf;
+  EXPECT_NE(pkt->icmp.checksum, 0);
+  free(buf);
+}

--- a/tests/unit/test_vsock_select.cpp
+++ b/tests/unit/test_vsock_select.cpp
@@ -1,0 +1,80 @@
+#include <gtest/gtest.h>
+#include <errno.h>
+
+extern "C" {
+#include "vsock.h"
+}
+
+class VsockSelectTest : public ::testing::Test {};
+
+// ping_socket_select が成功したとき、fd が有効で ops が設定されること
+TEST_F(VsockSelectTest, SelectSetsValidFdAndOps) {
+  t_socket_st state = {};
+  int ret = ping_socket_select(&state);
+
+  if (ret < 0) {
+    GTEST_SKIP() << "socket creation requires privilege or is unavailable";
+  }
+
+  EXPECT_GE(state.fd, 0);
+  EXPECT_NE(state.ops, nullptr);
+  EXPECT_TRUE(state.socktype == SOCK_RAW || state.socktype == SOCK_DGRAM);
+  close(state.fd);
+}
+
+// SOCK_RAW が取れたとき ops は raw_ops を指すこと
+TEST_F(VsockSelectTest, RawSocketGetsRawOps) {
+  t_socket_st state = {};
+  int fd = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP);
+  if (fd < 0) {
+    GTEST_SKIP() << "SOCK_RAW not available (no privilege)";
+  }
+  close(fd);
+
+  ping_socket_select(&state);
+  EXPECT_EQ(state.socktype, SOCK_RAW);
+  EXPECT_EQ(state.ops, &Ping_socket_raw_ops);
+  close(state.fd);
+}
+
+// SOCK_DGRAM が選ばれたとき ops は dgram_ops を指すこと
+// (SOCK_RAW が取れる環境では実行不可なのでスキップ)
+TEST_F(VsockSelectTest, DgramSocketGetsDgramOps) {
+  int fd = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP);
+  if (fd >= 0) {
+    close(fd);
+    GTEST_SKIP() << "SOCK_RAW available; DGRAM fallback path not exercised";
+  }
+  if (errno != EPERM && errno != EACCES) {
+    GTEST_SKIP() << "unexpected errno, skip";
+  }
+
+  t_socket_st state = {};
+  int ret = ping_socket_select(&state);
+  if (ret < 0) {
+    GTEST_SKIP() << "neither RAW nor DGRAM socket available";
+  }
+
+  EXPECT_EQ(state.socktype, SOCK_DGRAM);
+  EXPECT_EQ(state.ops, &Ping_socket_dgram_ops);
+  close(state.fd);
+}
+
+// 失敗時に fd と socktype が -1 になること
+// (通常環境では再現困難なので ops ポインタの一貫性を確認)
+TEST_F(VsockSelectTest, OpsMatchSocktype) {
+  t_socket_st state = {};
+  int ret = ping_socket_select(&state);
+  if (ret < 0) {
+    GTEST_SKIP() << "socket not available";
+  }
+
+  if (state.socktype == SOCK_RAW) {
+    EXPECT_EQ(state.ops, &Ping_socket_raw_ops);
+  } else if (state.socktype == SOCK_DGRAM) {
+    EXPECT_EQ(state.ops, &Ping_socket_dgram_ops);
+  } else {
+    FAIL() << "unexpected socktype: " << state.socktype;
+  }
+  close(state.fd);
+}


### PR DESCRIPTION
## Summary

- `lib/vsock/` に vsock の vtable インターフェース (`vsock.h`/`vsock.c`) を追加
- RAW ソケットアダプター (`vsock_raw.c`) と DGRAM ソケットアダプター (`vsock_dgram.c`) を実装
- `include/ft_ping/ft_ping.h` の公開 API を更新
- `CMakeLists.txt` をビルド構成に合わせて修正
- C言語における vtable パターンのドキュメント (`docs/c-vtable-pattern.md`) を追加

Closes #40

## Test plan

- [x] `cmake` でビルドが通ることを確認
- [x] RAW/DGRAM アダプターが正しく初期化されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)