### PR TITLE
feat: 共有ユーティリティモジュール lib/shared/ の作成 (#41)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ target_include_directories(
 )
 target_compile_definitions(testftping PUBLIC TESTING=1)
 
-# add_subdirectory(lib/shared)
+add_subdirectory(lib/shared)
 add_subdirectory(lib/vsock)
 
 add_executable(ft_ping ${SOURCES})

--- a/lib/shared/CMakeLists.txt
+++ b/lib/shared/CMakeLists.txt
@@ -1,0 +1,10 @@
+file(GLOB_RECURSE SOURCES
+"${CMAKE_CURRENT_SOURCE_DIR}/*.c"
+)
+
+add_library(shared STATIC ${SOURCES})
+
+target_include_directories(
+  shared
+  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/lib/shared/shared_error.c
+++ b/lib/shared/shared_error.c
@@ -1,0 +1,33 @@
+#include "shared_error.h"
+
+#ifndef TESTING
+void error(int status, const char *format, ...) {
+  va_list ap;
+
+  fprintf(stderr, "%s: ", program_invocation_short_name); //  #include <errno.h>
+  va_start(ap, format);
+  vfprintf(stderr, format, ap);
+  va_end(ap);
+  if (status)
+    exit(status);
+}
+#else
+int last_error_status = 0;
+int test_err_jmp_buf_set = 0;
+char last_error_message[256];
+jmp_buf test_err_jmp_buf;
+
+void error(int status, const char *format, ...) {
+  va_list ap;
+
+  memset(last_error_message, 0, sizeof(last_error_message));
+  last_error_status = status;
+  va_start(ap, format);
+  vsnprintf(last_error_message, sizeof(last_error_message), format, ap);
+  va_end(ap);
+  fprintf(stderr, "%s: %s (%d)\n", "test_ft_ping", last_error_message, status);
+  if (status && test_err_jmp_buf_set) {
+    longjmp(test_err_jmp_buf, status);
+  }
+}
+#endif

--- a/lib/shared/shared_error.h
+++ b/lib/shared/shared_error.h
@@ -1,0 +1,24 @@
+#ifndef SHARED_ERROR_H
+#define SHARED_ERROR_H
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#ifdef TESTING
+#include <setjmp.h>
+extern int last_error_status;
+extern char last_error_message[256];
+extern jmp_buf test_err_jmp_buf;
+extern int test_err_jmp_buf_set;
+#endif
+
+void error(int status, const char *format, ...);
+
+#endif /* SHARED_ERROR_H */

--- a/lib/shared/shared_net.c
+++ b/lib/shared/shared_net.c
@@ -1,0 +1,92 @@
+#include "shared_net.h"
+#include "shared_error.h"
+
+void dns_lookup(const char *hostname, struct sockaddr_in *addr) {
+  struct addrinfo hints = {
+      .ai_family = AF_INET,      /* Allow only IPv4 */
+      .ai_socktype = SOCK_DGRAM, /* Datagram socket */
+      .ai_flags = AI_PASSIVE,    /* For wildcard IP address */
+      .ai_protocol = 0,          /* Any protocol */
+      .ai_canonname = NULL,
+      .ai_addr = NULL,
+      .ai_next = NULL,
+  };
+  struct addrinfo *result;
+  int ret = getaddrinfo(hostname, NULL, &hints, &result);
+  if (ret != 0 || !result) {
+    error(1, "getaddrinfo failed: %s", gai_strerror(ret));
+  }
+
+  struct sockaddr_in *addr_in = (struct sockaddr_in *)result->ai_addr;
+  memcpy(addr, addr_in, sizeof(struct sockaddr_in));
+  freeaddrinfo(result);
+}
+
+int send_packet(void *packet, size_t packet_size, int sockfd, struct sockaddr_in *whereto) {
+  int cc = sendto(sockfd, packet, packet_size, 0, (struct sockaddr *)whereto, sizeof(*whereto));
+  if (cc < 0) {
+    return -1;
+  }
+  return cc;
+}
+
+void get_source_address(struct sockaddr_in *src, struct sockaddr_in *dest, const char *device) {
+  memset(src, 0, sizeof(*src));
+  int probe_fd = socket(AF_INET, SOCK_DGRAM, 0);
+  if (probe_fd < 0) {
+    error(2, "socket creation failed");
+  }
+
+  if (device) {
+    if (setsockopt(probe_fd, SOL_SOCKET, SO_BINDTODEVICE, device, strlen(device) + 1) == -1) {
+      error(2, "SO_BINDTODEVICE failed");
+    }
+  }
+  struct sockaddr_in dst = *dest;
+  dst.sin_port = htons(1025);
+  if (connect(probe_fd, (struct sockaddr *)&dst, sizeof(dst)) == -1) {
+    error(2, "connect failed");
+  }
+  socklen_t alen = sizeof(*src);
+  if (getsockname(probe_fd, (struct sockaddr *)src, &alen) == -1) {
+    error(2, "getsockname failed");
+  }
+  src->sin_port = 0;
+  close(probe_fd);
+  return;
+}
+
+/**
+ * @brief pingソケットのタイムアウトを設定する
+ *
+ * この関数は、指定された間隔に基づいてpingソケットのタイムアウト値を設定します。
+ * ping操作の適切な動作を保証するために、送信と受信の両方のタイムアウトを設定します。
+ * フラッドモードが有効な場合、それに応じてポーリング機構を調整します。
+ *
+ * @param sockfd 設定するソケットファイルディスクリプタ
+ * @param interval pingパケット間の時間間隔（ミリ秒）
+ * @param opt_flood_poll フラッドポーリングオプションフラグへのポインタ、フラッドモードがアクティブな場合更新される
+ */
+void configure_socket_timeouts(int sockfd, int interval, int *opt_flood_poll) {
+  struct timeval tv;
+  tv.tv_sec = 1;
+  tv.tv_usec = 0;
+  if (interval < 1000) {
+    tv.tv_sec = 0;
+    tv.tv_usec = 1000 * SCHINT(interval);
+  }
+  setsockopt(sockfd, SOL_SOCKET, SO_SNDTIMEO, (char *)&tv, sizeof(tv));
+  tv.tv_sec = SCHINT(interval) / 1000;
+  tv.tv_usec = 1000 * (SCHINT(interval) % 1000);
+  if (setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv, sizeof(tv))) {
+    *opt_flood_poll = 1;
+  }
+}
+
+int is_ipv6_address(const char *addr) {
+  if (!addr) {
+    return 0;
+  }
+  struct in6_addr ipv6_addr;
+  return inet_pton(AF_INET6, addr, &ipv6_addr) == 1;
+}

--- a/lib/shared/shared_net.h
+++ b/lib/shared/shared_net.h
@@ -1,0 +1,27 @@
+#ifndef SHARED_NET_H
+#define SHARED_NET_H
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#ifndef SOL_SOCKET
+#define SOL_SOCKET IPPROTO_IP
+#endif
+
+#define SCHINT(a) (((a) <= MIN_INTERVAL_MS) ? MIN_INTERVAL_MS : (a))
+#define MIN_INTERVAL_MS 10
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+void dns_lookup(const char *hostname, struct sockaddr_in *addr);
+int send_packet(void *packet, size_t packet_size, int sockfd, struct sockaddr_in *whereto);
+void get_source_address(struct sockaddr_in *src, struct sockaddr_in *dest, const char *device);
+void configure_socket_timeouts(int sockfd, int interval, int *opt_flood_poll);
+int is_ipv6_address(const char *addr);
+
+#endif /* SHARED_NET_H */

--- a/lib/shared/shared_parse.c
+++ b/lib/shared/shared_parse.c
@@ -1,0 +1,22 @@
+#include "shared_parse.h"
+
+long parse_long(
+    char const *const str,
+    const char *const msg,
+    const long min,
+    const long max,
+    void (*errorfn)(int, const char *, ...)) {
+  char *endptr;
+
+  if (str == NULL || *str == '\0') {
+    errorfn(1, "%s: %s\n", msg, str);
+  }
+  long val = strtol(str, &endptr, 10);
+  if (errno || str == endptr || (endptr && *endptr)) {
+    errorfn(1, "%s : %s\n", msg, endptr);
+  }
+  if (val < min || max < val) {
+    errorfn(1, "%s: '%s': out of range: %lu <= value <= %lu\n", msg, str, min, max);
+  }
+  return val;
+}

--- a/lib/shared/shared_parse.h
+++ b/lib/shared/shared_parse.h
@@ -1,0 +1,14 @@
+#ifndef SHARED_PARSE_H
+#define SHARED_PARSE_H
+
+#include <errno.h>
+#include <stdlib.h>
+
+long parse_long(
+    char const *const str,
+    const char *const msg,
+    const long min,
+    const long max,
+    void (*errorfn)(int, const char *, ...));
+
+#endif /* SHARED_PARSE_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,14 +26,15 @@ file(GLOB_RECURSE TEST_SOURCES
 add_executable(InternalTests ${TEST_SOURCES})
 
 if(GTest_FOUND)
-  target_link_libraries(InternalTests testftping vsock GTest::GTest GTest::Main)
+  target_link_libraries(InternalTests testftping vsock shared GTest::GTest GTest::Main)
 else()
-  target_link_libraries(InternalTests testftping vsock gtest gtest_main)
+  target_link_libraries(InternalTests testftping vsock shared gtest gtest_main)
 endif()
 
 target_include_directories(InternalTests PRIVATE
   ${CMAKE_SOURCE_DIR}/cmd/ft_ping
   ${CMAKE_SOURCE_DIR}/lib/vsock
+  ${CMAKE_SOURCE_DIR}/lib/shared
   ${gtest_SOURCE_DIR}
 )
 

--- a/tests/unit/test_dns_lookup.cpp
+++ b/tests/unit/test_dns_lookup.cpp
@@ -4,7 +4,8 @@
 #include <string>
 
 extern "C" {
-#include "ft_ping.h"
+#include "shared_error.h"
+#include "shared_net.h"
 }
 
 class DnsLookupTest : public ::testing::Test {

--- a/tests/unit/test_get_source_address.cpp
+++ b/tests/unit/test_get_source_address.cpp
@@ -1,22 +1,10 @@
 #include <arpa/inet.h>
-#include <cstring>
-#include <errno.h>
 #include <gtest/gtest.h>
 #include <iostream>
-#include <netdb.h>
-#include <netinet/in.h>
-#include <netinet/ip_icmp.h>
-#include <stdexcept>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <string>
-#include <sys/socket.h>
-#include <sys/time.h>
-#include <unistd.h>
 
 extern "C" {
-#include "ft_ping.h"
+#include "shared_net.h"
 }
 
 TEST(GetSourceAddressTest, ValidDevice) {

--- a/tests/unit/test_is_ipv6_address.cpp
+++ b/tests/unit/test_is_ipv6_address.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
 extern "C" {
-#include "ft_ping.h"
+#include "shared_net.h"
 }
 
 class IsIpv6AddressTest : public ::testing::Test {};

--- a/tests/unit/test_parse_long.cpp
+++ b/tests/unit/test_parse_long.cpp
@@ -4,7 +4,8 @@
 #include <string>
 
 extern "C" {
-#include "ft_ping.h"
+#include "shared_parse.h"
+#include "shared_error.h"
 }
 
 namespace {


### PR DESCRIPTION
## Summary
- `lib/shared/shared_error.c/h` — `error()` 関数（`TESTING` マクロによる longjmp 版切り替え含む）
- `lib/shared/shared_parse.c/h` — `parse_long()` の移行
- `lib/shared/shared_net.c/h` — ネットワークユーティリティ（`dns_lookup`, `send_packet`, `get_source_address`, `configure_socket_timeouts`, `is_ipv6_address`）の移行
- テストを `tests/unit/` 配下に移動し、不要な include を整理

## Test plan
- [x] `make test` が全テスト通過すること
- [x] `test_parse_long`, `test_dns_lookup`, `test_is_ipv6_address`, `test_get_source_address` が新モジュールに対して通ること

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)