### PR TITLE
update(test): tool_getparam のテストを追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,24 +22,8 @@ target_include_directories(
 )
 target_compile_definitions(testftping PUBLIC TESTING=1)
 
-add_subdirectory(lib/shared)
-add_subdirectory(lib/vsock)
-
-add_library(ping_stats OBJECT ${CMAKE_SOURCE_DIR}/lib/ping_stats.c)
-target_include_directories(ping_stats PUBLIC ${CMAKE_SOURCE_DIR}/lib)
-
-add_library(ping_icmp OBJECT ${CMAKE_SOURCE_DIR}/lib/ping_icmp.c)
-target_include_directories(ping_icmp PUBLIC ${CMAKE_SOURCE_DIR}/lib)
-
-add_library(ping_config OBJECT ${CMAKE_SOURCE_DIR}/lib/ping_config.c)
-target_include_directories(ping_config PUBLIC ${CMAKE_SOURCE_DIR}/lib)
-
-add_library(ping_loop OBJECT ${CMAKE_SOURCE_DIR}/lib/ping_loop.c)
-target_include_directories(ping_loop PUBLIC ${CMAKE_SOURCE_DIR}/lib)
-target_compile_definitions(ping_loop PUBLIC TESTING=1)
-
-add_library(ping_schedule OBJECT ${CMAKE_SOURCE_DIR}/lib/ping_schedule.c)
-target_include_directories(ping_schedule PUBLIC ${CMAKE_SOURCE_DIR}/lib)
+add_subdirectory(lib)
+add_subdirectory(src)
 
 add_executable(ft_ping ${SOURCES})
 

--- a/include/ft_ping/ft_ping.h
+++ b/include/ft_ping/ft_ping.h
@@ -19,15 +19,25 @@ struct rcvd_table {
 
 typedef struct ftping_session t_ftping_session; // 前方宣言
 
-typedef struct ftping_config {
+typedef struct ping_config {
+  const char *hostname;
   int datalen;
   int ttl;
   int tos;
-  long npackets;
-  int interval;
-  unsigned int opt_verbose;
-  unsigned int opt_adaptive;
-} t_ftping_config;
+  long count;
+  int interval_ms;
+  int deadline_sec;
+  uint32_t lingertime_us;
+  uint16_t ident;
+  int sndbuf;
+  int preload;
+  unsigned int opt_adaptive : 1;
+  unsigned int opt_flood_poll : 1;
+  unsigned int opt_verbose : 1;
+  unsigned int opt_ptimeofday : 1;
+} t_ping_config;
+
+void error(int status, const char *format, ...);
 
 typedef struct ftping_stats {
   int ntransmitted;
@@ -38,7 +48,7 @@ typedef struct ftping_stats {
   rcvd_table rcvd_tbl;
 } t_ftping_stats;
 
-typedef struct t_ping_session t_ping_session;  /* opaque */
+typedef struct t_ping_session t_ping_session; /* opaque */
 
 void ftping_init();
 void ftping_run();

--- a/include/ft_ping/ft_ping.h
+++ b/include/ft_ping/ft_ping.h
@@ -9,9 +9,9 @@
 
 typedef uint64_t bitmap_t;
 
-struct rcvd_table {
+typedef struct rcvd_table {
   bitmap_t bitmap[MAX_DUP_CHK / (sizeof(bitmap_t) * 8)];
-};
+} rcvd_table;
 
 /* ビット操作マクロ */
 #define BITMAP_WORD(tbl, bit) ((tbl)->bitmap[(bit) >> BITMAP_SHIFT])

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_subdirectory(shared)
+add_subdirectory(vsock)
+
+foreach(module ping_stats ping_icmp ping_config ping_loop ping_schedule)
+  add_library(${module} OBJECT ${CMAKE_CURRENT_SOURCE_DIR}/${module}.c)
+  target_include_directories(${module} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+  target_compile_definitions(${module} PUBLIC TESTING=1)
+endforeach()

--- a/lib/ping_config.c
+++ b/lib/ping_config.c
@@ -11,4 +11,7 @@ void ping_config_init(t_ping_config *config) {
   config->lingertime_us = 10 * 1000000;
   config->opt_adaptive = 0;
   config->opt_flood_poll = 0;
+  config->ident = 0;
+  config->sndbuf = 0;
+  config->preload = 1;
 }

--- a/lib/ping_config.h
+++ b/lib/ping_config.h
@@ -13,8 +13,13 @@ typedef struct ping_config {
   int interval_ms;
   int deadline_sec;
   uint32_t lingertime_us;
+  uint16_t ident;
+  int sndbuf;
+  int preload;
   unsigned int opt_adaptive : 1;
-  int opt_flood_poll;
+  unsigned int opt_flood_poll : 1;
+  unsigned int opt_verbose : 1;
+  unsigned int opt_ptimeofday : 1;
 } t_ping_config;
 
 void ping_config_init(t_ping_config *config);

--- a/lib/ping_loop.c
+++ b/lib/ping_loop.c
@@ -197,7 +197,7 @@ int ping_init(t_ping_session *session, char *target) {
   t_ping_net_state *net = &session->net;
   t_ping_config *config = &session->config;
 
-  net->ident = (uint16_t)(getpid() & 0xFFFF);
+  net->ident = config->ident ? config->ident : (uint16_t)(getpid() & 0xFFFF);
 
   if (ping_socket_select(&net->socket_state) < 0)
     error(1, "Failed to create socket: %s\n", strerror(errno));

--- a/lib/ping_loop.c
+++ b/lib/ping_loop.c
@@ -193,6 +193,63 @@ int ping_receive_replies(t_ping_session *session, t_ping_receive *received) {
   return (int)ret;
 }
 
+/**
+ * @brief ソケットの送受信バッファサイズを設定する。
+ * @see https://github.com/GawinGowin/ft_ping/wiki/set_socket_buff
+ *
+ * 1パケットがカーネル内で消費するメモリを粗く見積もり、SO_SNDBUF と SO_RCVBUF を
+ * 適切なサイズに設定する。iputils の sock_setbufs() (ping_common.c:443) に相当し、
+ * ping.c:1034 と同じ計算式を使用する。
+ *
+ * ### バッファサイズの計算式
+ * ```
+ * send = (datalen + 8)                              // ICMPヘッダ(8B) + データ
+ *      + ceil(send / 512) * (IPV4_HEADER_SIZE + 240) // sk_buff オーバーヘッド見積もり
+ * ```
+ * `ceil(send / 512)` はカーネルが sk_buff 単位でメモリを管理するための切り上げ。
+ * `IPV4_HEADER_SIZE + 240 = 260` は iputils の `optlen + 20 + 16 + 64 + 160` と等価
+ * （ft_ping は IP オプション未対応のため optlen=0 として固定）。
+ *
+ * ### SO_SNDBUF
+ * `-S` オプション未指定時は `send`（1パケット分）を設定する。
+ *
+ * ### SO_RCVBUF
+ * `-l preload` 個のパケットを同時に空中に飛ばせるよう `send * preload` を設定する。
+ * カーネルの rmem_max による切り詰めが発生した場合は警告を出す。
+ *
+ * @param fd      設定対象のソケットファイルディスクリプタ
+ * @param config  datalen / sndbuf / preload を参照する設定構造体
+ */
+static void set_socket_buff(int fd, t_ping_config *config) {
+  size_t send = (size_t)(config->datalen + 8);
+  send += ((send + 511) / 512) * (IPV4_HEADER_SIZE + 240);
+  if (send > INT_MAX)
+    error(1, "Buffer size too large: %zu\n", send);
+
+  int sndbuf = config->sndbuf ? config->sndbuf : (int)send;
+  if (setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf)) < 0)
+    error(1, "setsockopt SO_SNDBUF failed: %s\n", strerror(errno));
+
+  int hold;
+  if ((int)send > INT_MAX / config->preload) {
+    error(0, "WARNING: buffer size overflow, reduce packet size or preload\n");
+    hold = INT_MAX;
+  } else {
+    hold = (int)send * config->preload;
+  }
+
+  int rcvbuf = hold;
+  if (hold < 65536)
+    hold = 65536;
+
+  setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &hold, sizeof(hold));
+  socklen_t tmplen = sizeof(hold);
+  if (getsockopt(fd, SOL_SOCKET, SO_RCVBUF, &hold, &tmplen) == 0) {
+    if (hold < rcvbuf)
+      error(0, "WARNING: probably, rcvbuf is not enough to hold preload\n");
+  }
+}
+
 int ping_init(t_ping_session *session, char *target) {
   t_ping_net_state *net = &session->net;
   t_ping_config *config = &session->config;
@@ -211,6 +268,8 @@ int ping_init(t_ping_session *session, char *target) {
   int on = 1;
   if (setsockopt(fd, IPPROTO_IP, IP_RECVERR, &on, sizeof(on)) < 0)
     error(1, "setsockopt IP_RECVERR failed: %s\n", strerror(errno));
+
+  set_socket_buff(fd, config);
 
   net->socket_state.ops->extra_configure(fd);
 

--- a/lib/ping_loop.h
+++ b/lib/ping_loop.h
@@ -18,6 +18,8 @@
 #include "shared/shared_net.h"
 #include "vsock/vsock.h"
 
+#define IPV4_HEADER_SIZE 20
+
 typedef struct ping_timer {
   struct timeval prev_send_time;
   unsigned long schedule_waittime;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(tool_getparam OBJECT ${CMAKE_CURRENT_SOURCE_DIR}/tool_getparam.c)
+target_include_directories(tool_getparam PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_SOURCE_DIR}/include/ft_ping
+  ${CMAKE_SOURCE_DIR}/lib
+)
+target_compile_definitions(tool_getparam PUBLIC TESTING=1)

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1,0 +1,50 @@
+
+#include "tool_getparam.h"
+
+// tool_show_usage()
+
+int tool_parse_args(int *argc, char ***argv, t_ping_config *config) {
+  int ch;
+  while ((ch = getopt(*argc, *argv, "AhvDe:t:Q:c:S:s:l:w:")) != EOF) {
+    switch (ch) {
+    case 'A':
+      config->opt_adaptive = 1;
+      break;
+    case 'v':
+      config->opt_verbose = 1;
+      break;
+    case 'D':
+      config->opt_ptimeofday = 1;
+      break;
+    case 't':
+      config->ttl = parse_long(optarg, "invalid argument", 1, 255, error);
+      break;
+    case 'Q':
+      config->tos = parse_long(optarg, "invalid argument", 0, 255, error);
+      break;
+    case 'c':
+      config->count = parse_long(optarg, "invalid argument", 0, LONG_MAX, error);
+      break;
+    case 'e':
+      config->ident = htons((uint16_t)parse_long(optarg, "invalid argument", 0, 0xFFFF, error));
+      break;
+    case 'S':
+      config->sndbuf = parse_long(optarg, "invalid argument", 0, INT_MAX, error);
+      break;
+    case 's':
+      config->datalen = parse_long(optarg, "invalid argument", 0, INT_MAX, error);
+      break;
+    case 'l':
+      config->preload = parse_long(optarg, "invalid argument", 0, 65536, error);
+      break;
+    case 'w':
+      config->deadline_sec = parse_long(optarg, "invalid argument", 0, INT_MAX, error);
+      break;
+    default:
+      return (2);
+    }
+  }
+  *argc -= optind;
+  *argv += optind;
+  return (0);
+}

--- a/src/tool_getparam.h
+++ b/src/tool_getparam.h
@@ -1,0 +1,17 @@
+#ifndef TOOL_GETPARAM_H
+#define TOOL_GETPARAM_H
+
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "ft_ping.h"
+
+#include <limits.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int tool_parse_args(int *argc, char ***argv, t_ping_config *config);
+
+#endif /* TOOL_GETPARAM_H */

--- a/src/tool_getparam.h
+++ b/src/tool_getparam.h
@@ -1,16 +1,19 @@
 #ifndef TOOL_GETPARAM_H
 #define TOOL_GETPARAM_H
 
-
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
 
 #include "ft_ping.h"
 
+#include <arpa/inet.h>
 #include <limits.h>
 #include <stdio.h>
 #include <unistd.h>
+
+#include "shared/shared_error.h"
+#include "shared/shared_parse.h"
 
 int tool_parse_args(int *argc, char ***argv, t_ping_config *config);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,18 +22,26 @@ file(GLOB_RECURSE TEST_SOURCES
 "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
 )
 
+set(FTPING_LIBS
+  testftping vsock shared
+  ping_stats ping_icmp ping_config ping_loop ping_schedule
+  tool_getparam
+)
+
 #..:: ft_ping_test ::..
 add_executable(ft_ping_test ${TEST_SOURCES})
 
 if(GTest_FOUND)
-  target_link_libraries(ft_ping_test testftping vsock shared ping_stats ping_icmp ping_config ping_loop ping_schedule GTest::GTest GTest::Main)
+  target_link_libraries(ft_ping_test ${FTPING_LIBS} GTest::GTest GTest::Main)
 else()
-  target_link_libraries(ft_ping_test testftping vsock shared ping_stats ping_icmp ping_config ping_loop ping_schedule gtest gtest_main)
+  target_link_libraries(ft_ping_test ${FTPING_LIBS} gtest gtest_main)
 endif()
 
 target_include_directories(ft_ping_test PRIVATE
   ${CMAKE_SOURCE_DIR}/cmd/ft_ping
   ${CMAKE_SOURCE_DIR}/lib
+  ${CMAKE_SOURCE_DIR}/src
+  ${CMAKE_SOURCE_DIR}/include/ft_ping
   ${gtest_SOURCE_DIR}
 )
 

--- a/tests/tool/test_tool_getparam.cpp
+++ b/tests/tool/test_tool_getparam.cpp
@@ -1,0 +1,359 @@
+#include <arpa/inet.h>
+#include <climits>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <initializer_list>
+#include <string>
+#include <vector>
+
+extern "C" {
+#include "ping_config.h"
+#include "shared/shared_error.h"
+#include "tool_getparam.h"
+}
+
+class ToolParseArgsTest : public ::testing::Test {
+protected:
+  t_ping_config config;
+  std::vector<char *> argv_storage;
+
+  void SetUp() override {
+    ping_config_init(&config);
+    optind = 1;
+    opterr = 0;
+    test_err_jmp_buf_set = 0;
+    last_error_status = 0;
+    memset(last_error_message, 0, sizeof(last_error_message));
+  }
+
+  void TearDown() override {
+    for (auto p : argv_storage)
+      free(p);
+    argv_storage.clear();
+    test_err_jmp_buf_set = 0;
+  }
+
+  /* {"ft_ping", "-t", "64", "host"} → argc=4, argv=char**  */
+  void make_argv(std::initializer_list<const char *> args, int *argc, char ***argv) {
+    argv_storage.clear();
+    for (auto s : args)
+      argv_storage.push_back(strdup(s));
+    *argc = (int)argv_storage.size();
+    *argv = argv_storage.data();
+  }
+};
+
+/* ─── A. ブールフラグ ─────────────────────────────────────── */
+
+TEST_F(ToolParseArgsTest, AdaptiveFlag) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-A", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.opt_adaptive, 1u);
+}
+
+TEST_F(ToolParseArgsTest, VerboseFlag) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-v", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.opt_verbose, 1u);
+}
+
+TEST_F(ToolParseArgsTest, PrintTimestampFlag) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-D", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.opt_ptimeofday, 1u);
+}
+
+/* ─── B. 数値フラグ（正常値）──────────────────────────────── */
+
+TEST_F(ToolParseArgsTest, TtlFlag) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-t", "128", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.ttl, 128); /* デフォルト 64 と異なる値で確認 */
+}
+
+TEST_F(ToolParseArgsTest, TosFlag) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-Q", "16", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.tos, 16);
+}
+
+TEST_F(ToolParseArgsTest, CountFlag) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-c", "5", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.count, 5);
+}
+
+TEST_F(ToolParseArgsTest, IdentFlag) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-e", "1234", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.ident, htons(1234));
+}
+
+TEST_F(ToolParseArgsTest, SndbufFlag) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-S", "65536", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.sndbuf, 65536);
+}
+
+TEST_F(ToolParseArgsTest, DatalenFlag) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-s", "128", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.datalen, 128);
+}
+
+TEST_F(ToolParseArgsTest, PreloadFlag) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-l", "3", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.preload, 3);
+}
+
+TEST_F(ToolParseArgsTest, DeadlineFlag) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-w", "10", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.deadline_sec, 10);
+}
+
+/* ─── C. 境界値 ───────────────────────────────────────────── */
+
+TEST_F(ToolParseArgsTest, TtlMin) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-t", "1", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.ttl, 1);
+}
+
+TEST_F(ToolParseArgsTest, TtlMax) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-t", "255", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.ttl, 255);
+}
+
+TEST_F(ToolParseArgsTest, TosMin) {
+  int argc;
+  char **argv;
+  config.tos = 100; /* デフォルト 0 と異なる値にしてから上書きを確認 */
+  make_argv({"ft_ping", "-Q", "0", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.tos, 0);
+}
+
+TEST_F(ToolParseArgsTest, TosMax) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-Q", "255", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.tos, 255);
+}
+
+TEST_F(ToolParseArgsTest, CountZeroMeansInfinite) {
+  int argc;
+  char **argv;
+  config.count = 5; /* デフォルト 0 と異なる値にしてから上書きを確認 */
+  make_argv({"ft_ping", "-c", "0", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.count, 0);
+}
+
+TEST_F(ToolParseArgsTest, IdentZero) {
+  int argc;
+  char **argv;
+  config.ident = htons(999); /* デフォルト 0 と異なる値にしてから上書きを確認 */
+  make_argv({"ft_ping", "-e", "0", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.ident, (uint16_t)htons(0));
+}
+
+TEST_F(ToolParseArgsTest, IdentMax) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-e", "65535", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.ident, htons(65535));
+}
+
+TEST_F(ToolParseArgsTest, PreloadZero) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-l", "0", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.preload, 0);
+}
+
+TEST_F(ToolParseArgsTest, PreloadMax) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-l", "65536", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.preload, 65536);
+}
+
+TEST_F(ToolParseArgsTest, DatalenZero) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-s", "0", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.datalen, 0);
+}
+
+/* ─── D. エラーケース（範囲外・不正値）──────────────────── */
+
+TEST_F(ToolParseArgsTest, TtlBelowMin) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-t", "0", "host"}, &argc, &argv);
+  test_err_jmp_buf_set = 1;
+  if (setjmp(test_err_jmp_buf) == 0) {
+    tool_parse_args(&argc, &argv, &config);
+    FAIL() << "Expected error() to be called";
+  }
+  EXPECT_EQ(last_error_status, 1);
+}
+
+TEST_F(ToolParseArgsTest, TtlAboveMax) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-t", "256", "host"}, &argc, &argv);
+  test_err_jmp_buf_set = 1;
+  if (setjmp(test_err_jmp_buf) == 0) {
+    tool_parse_args(&argc, &argv, &config);
+    FAIL() << "Expected error() to be called";
+  }
+  EXPECT_EQ(last_error_status, 1);
+}
+
+TEST_F(ToolParseArgsTest, TosAboveMax) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-Q", "256", "host"}, &argc, &argv);
+  test_err_jmp_buf_set = 1;
+  if (setjmp(test_err_jmp_buf) == 0) {
+    tool_parse_args(&argc, &argv, &config);
+    FAIL() << "Expected error() to be called";
+  }
+  EXPECT_EQ(last_error_status, 1);
+}
+
+TEST_F(ToolParseArgsTest, IdentAboveMax) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-e", "65536", "host"}, &argc, &argv);
+  test_err_jmp_buf_set = 1;
+  if (setjmp(test_err_jmp_buf) == 0) {
+    tool_parse_args(&argc, &argv, &config);
+    FAIL() << "Expected error() to be called";
+  }
+  EXPECT_EQ(last_error_status, 1);
+}
+
+TEST_F(ToolParseArgsTest, PreloadAboveMax) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-l", "65537", "host"}, &argc, &argv);
+  test_err_jmp_buf_set = 1;
+  if (setjmp(test_err_jmp_buf) == 0) {
+    tool_parse_args(&argc, &argv, &config);
+    FAIL() << "Expected error() to be called";
+  }
+  EXPECT_EQ(last_error_status, 1);
+}
+
+TEST_F(ToolParseArgsTest, NonNumericTtl) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-t", "abc", "host"}, &argc, &argv);
+  test_err_jmp_buf_set = 1;
+  if (setjmp(test_err_jmp_buf) == 0) {
+    tool_parse_args(&argc, &argv, &config);
+    FAIL() << "Expected error() to be called";
+  }
+  EXPECT_EQ(last_error_status, 1);
+}
+
+/* ─── E. 不明フラグ ───────────────────────────────────────── */
+
+TEST_F(ToolParseArgsTest, UnknownFlagReturns2) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-x", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 2);
+}
+
+TEST_F(ToolParseArgsTest, HelpFlagReturns2) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-h", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 2);
+}
+
+/* ─── F. argc/argv の調整 ─────────────────────────────────── */
+
+TEST_F(ToolParseArgsTest, ArgvAdjustedToRemainingArgs) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-v", "-c", "3", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(argc, 1);
+  EXPECT_STREQ(argv[0], "host");
+}
+
+TEST_F(ToolParseArgsTest, NoOptionsLeavesHostname) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(argc, 1);
+  EXPECT_STREQ(argv[0], "host");
+}
+
+TEST_F(ToolParseArgsTest, MultipleOptionsAndHostname) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-v", "-A", "-D", "-t", "128", "-c", "10", "8.8.8.8"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.opt_verbose, 1u);
+  EXPECT_EQ(config.opt_adaptive, 1u);
+  EXPECT_EQ(config.opt_ptimeofday, 1u);
+  EXPECT_EQ(config.ttl, 128);
+  EXPECT_EQ(config.count, 10);
+  EXPECT_EQ(argc, 1);
+  EXPECT_STREQ(argv[0], "8.8.8.8");
+}
+
+/* ─── G. デフォルト値が変化しないことの確認 ─────────────── */
+
+TEST_F(ToolParseArgsTest, UnrelatedFieldsUnchanged) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-v", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  /* -v 以外はデフォルト値のまま */
+  EXPECT_EQ(config.datalen, 56);
+  EXPECT_EQ(config.ttl, 64);
+  EXPECT_EQ(config.count, 0);
+  EXPECT_EQ(config.preload, 1);
+}


### PR DESCRIPTION
## Summary
- add: tool_parse_args を追加 (src/tool_getparam.c/h)
- update: フラグから ident を取得 (ping_config に ident/sndbuf/preload 追加)
- add: set_socket_buff 機能を追加 (ping_loop.c に SO_SNDBUF/SO_RCVBUF 設定)
- update(test): tool_getparam の網羅的テストを追加 (33ケース)
- CMakeLists を lib/CMakeLists.txt・src/CMakeLists.txt に分割して整理

## Test plan
- [ ] `cmake --build build --target ft_ping_test && ./build/tests/ft_ping_test` で全テストパスを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)