### PR TITLE
feat: `on_exit` コールバックを `src/tool_cleanup.c` に移行

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,9 +21,16 @@ target_include_directories(tool_output PUBLIC
 )
 target_compile_definitions(tool_output PUBLIC TESTING=1)
 
+add_library(tool_cleanup OBJECT ${CMAKE_CURRENT_SOURCE_DIR}/tool_cleanup.c)
+target_include_directories(tool_cleanup PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_SOURCE_DIR}/include/ft_ping
+)
+target_compile_definitions(tool_cleanup PUBLIC TESTING=1)
+
 add_executable(tool_ft_ping ${CMAKE_CURRENT_SOURCE_DIR}/tool_main.c)
 target_include_directories(tool_ft_ping PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/include/ft_ping
 )
-target_link_libraries(tool_ft_ping PRIVATE tool_getparam tool_signal tool_output ftping ping_loop ping_stats ping_config ping_icmp ping_schedule vsock shared)
+target_link_libraries(tool_ft_ping PRIVATE tool_getparam tool_signal tool_output tool_cleanup ftping ping_loop ping_stats ping_config ping_icmp ping_schedule vsock shared)

--- a/src/tool_cleanup.c
+++ b/src/tool_cleanup.c
@@ -1,0 +1,30 @@
+#include "tool_cleanup.h"
+#include "tool_signal.h"
+
+#include <stdlib.h>
+
+static t_ping_session *s_session = NULL;
+static int s_done = 0;
+
+static void tool_cleanup_atexit(void) {
+  if (s_session && !s_done) {
+    tool_cleanup(s_session);
+  }
+}
+
+void tool_cleanup_register(t_ping_session *session) {
+  if (s_session)
+    return;
+  s_session = session;
+  atexit(tool_cleanup_atexit);
+}
+
+void tool_cleanup(t_ping_session *session) {
+  if (s_done)
+    return;
+  s_done = 1;
+  tool_signal_teardown();
+  if (session)
+    ftping_cleanup(session);
+  s_session = NULL;
+}

--- a/src/tool_cleanup.h
+++ b/src/tool_cleanup.h
@@ -1,0 +1,9 @@
+#ifndef TOOL_CLEANUP_H
+#define TOOL_CLEANUP_H
+
+#include "ft_ping.h"
+
+void tool_cleanup_register(t_ping_session *session);
+void tool_cleanup(t_ping_session *session);
+
+#endif /* TOOL_CLEANUP_H */

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -1,4 +1,5 @@
 #include "ft_ping.h"
+#include "tool_cleanup.h"
 #include "tool_getparam.h"
 #include "tool_output.h"
 #include "tool_signal.h"
@@ -28,6 +29,7 @@ int main(int argc, char **argv) {
     fprintf(stderr, "ft_ping: failed to initialize session\n");
     return 1;
   }
+  tool_cleanup_register(session);
   tool_setup_signals(session);
 
   ftping_set_reply_handler(session, tool_output_reply, &config);
@@ -39,6 +41,6 @@ int main(int argc, char **argv) {
   t_ftping_summary summary = ftping_get_summary(session);
   tool_output_finish(&summary);
 
-  ftping_cleanup(session);
+  tool_cleanup(session);
   return 0;
 }

--- a/src/tool_signal.c
+++ b/src/tool_signal.c
@@ -26,3 +26,5 @@ void tool_setup_signals(t_ping_session *session) {
 
   signal(SIGQUIT, SIG_IGN);
 }
+
+void tool_signal_teardown(void) { s_session = NULL; }

--- a/src/tool_signal.c
+++ b/src/tool_signal.c
@@ -1,3 +1,7 @@
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include "tool_signal.h"
 #include <signal.h>
 #include <string.h>

--- a/src/tool_signal.h
+++ b/src/tool_signal.h
@@ -4,5 +4,6 @@
 #include "ft_ping.h"
 
 void tool_setup_signals(t_ping_session *session);
+void tool_signal_teardown(void);
 
 #endif /* TOOL_SIGNAL_H */


### PR DESCRIPTION
## Summary
- `src/tool_cleanup.c/h` を新規作成し、`tool_cleanup()` / `tool_cleanup_register()` を実装
  - `atexit` ハンドラ + 冪等化により、`error()→exit()` 経路でも socket close される安全網を提供
  - 旧 `cmd/ft_ping/usecases.c::cleanup_usecase()` の tool 層責務を新アーキテクチャ側に移植
- `src/tool_signal.c/h` に `tool_signal_teardown()` を追加し、cleanup 時に静的セッションポインタを失効
- `src/tool_main.c` を `tool_cleanup_register(session)` + `tool_cleanup(session)` 利用に更新
- `src/CMakeLists.txt` に `tool_cleanup` OBJECT ライブラリを追加し `tool_ft_ping` にリンク
- `tool_signal.c` に `_POSIX_C_SOURCE` を定義し、`struct sigaction` の可視性を保証

closes #51

## Test plan
- [x] `make tool_ft_ping` でビルド成功
- [x] `ctest` で 163/163 テスト pass
- [x] `tool_ft_ping -c 1 127.0.0.1` で正常動作（統計表示まで完走）
- [x] 引数欠落時に exit 1 で早期 return
- [x] valgrind による "definitely lost: 0 bytes" の確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)