### PR TITLE
update: 応答行に ttl を表示

### DIFF
--- a/include/ft_ping/ft_ping.h
+++ b/include/ft_ping/ft_ping.h
@@ -48,6 +48,7 @@ typedef struct ftping_reply {
   long triptime_us;         /* RTT [μs]、未測定なら -1 */
   int is_duplicate;         /* 重複なら 1 */
   struct timeval recv_time; /* gettimeofday(recv 時)。-D 用 */
+  int ttl;                  /* 受信パケットの IP TTL、不明なら 0 */
 } t_ftping_reply;
 
 /* 最終統計用の DTO。tool_output_finish が消費する。 */

--- a/lib/ping_loop.c
+++ b/lib/ping_loop.c
@@ -266,6 +266,7 @@ int ping_receive_replies(t_ping_session *session, t_ping_receive *received) {
       ping_stats_gather(&session->stats, seq, triptime, is_duplicate);
 
       if (session->reply_cb) {
+        int reply_ttl = session->net.socket_state.ops->extract_ttl(received->iov->iov_base, msg);
         t_ftping_reply ev = {
             .bytes = icmp_len,
             .from_addr = from ? from->sin_addr : (struct in_addr){0},
@@ -273,6 +274,7 @@ int ping_receive_replies(t_ping_session *session, t_ping_receive *received) {
             .triptime_us = triptime,
             .is_duplicate = is_duplicate,
             .recv_time = recv_time,
+            .ttl = reply_ttl,
         };
         session->reply_cb(&ev, session->reply_ctx);
       }
@@ -371,6 +373,10 @@ int ping_init(t_ping_session *session, char *target) {
   int on = 1;
   if (setsockopt(fd, IPPROTO_IP, IP_RECVERR, &on, sizeof(on)) < 0)
     error(1, "setsockopt IP_RECVERR failed: %s\n", strerror(errno));
+  /* DGRAM では受信 TTL を cmsg 経由でしか取れないので IP_RECVTTL を有効化する。
+   * RAW でも害はないが iputils と同じく失敗は警告に留める。 */
+  if (setsockopt(fd, IPPROTO_IP, IP_RECVTTL, &on, sizeof(on)) < 0)
+    error(0, "WARNING: setsockopt(IP_RECVTTL): %s\n", strerror(errno));
 
   set_socket_buff(fd, config);
 

--- a/lib/vsock/vsock.h
+++ b/lib/vsock/vsock.h
@@ -34,6 +34,9 @@ typedef struct socket_st {
 struct ping_socket_ops {
   int (*build_ipheader)(void *packet, const t_ipheader_ctx *ctx);
   struct icmphdr *(*extract_icmp)(void *packet, size_t packet_len, int *icmp_len_out);
+  /* TTL 取得: RAW は packet 先頭の IP ヘッダーから、DGRAM は msg の cmsg から取り出す。
+   * 不明なら 0 を返す。 */
+  int (*extract_ttl)(void *packet, const struct msghdr *msg);
   size_t (*packet_size)(size_t datalen);
   int (*extra_configure)(int fd);
 };

--- a/lib/vsock/vsock_dgram.c
+++ b/lib/vsock/vsock_dgram.c
@@ -1,5 +1,7 @@
 #include "vsock/vsock.h"
 
+#include <string.h>
+
 #include "ping_icmp.h"
 
 /* DGRAM は IP ヘッダー不要。ICMP ヘッダーのみ構築する */
@@ -18,6 +20,26 @@ struct icmphdr *extract_icmp_dgram(void *packet, size_t packet_len, int *icmp_le
   return (struct icmphdr *)packet;
 }
 
+/* DGRAM 受信: IP ヘッダーは届かない。IP_RECVTTL 由来の cmsg から取り出す。
+ * iputils ping4_parse_reply (reference/iputils/ping/ping.c:1667) と同じパターン。 */
+int extract_ttl_dgram(void *packet, const struct msghdr *msg) {
+  (void)packet;
+  if (msg == NULL)
+    return 0;
+  /* CMSG_NXTHDR は非 const の msghdr* を要求するためキャストする */
+  struct msghdr *mut = (struct msghdr *)msg;
+  for (struct cmsghdr *c = CMSG_FIRSTHDR(mut); c != NULL; c = CMSG_NXTHDR(mut, c)) {
+    if (c->cmsg_level != IPPROTO_IP || c->cmsg_type != IP_TTL)
+      continue;
+    if (c->cmsg_len < CMSG_LEN(sizeof(int)))
+      continue;
+    int ttl;
+    memcpy(&ttl, CMSG_DATA(c), sizeof(ttl));
+    return ttl;
+  }
+  return 0;
+}
+
 int extra_configure_dgram(int fd) {
   (void)fd;
   return 0;
@@ -28,5 +50,6 @@ size_t packet_size_dgram(size_t datalen) { return sizeof(struct icmphdr) + datal
 t_ping_socket_ops Ping_socket_dgram_ops = {
     .build_ipheader = build_ipheader_dgram,
     .extract_icmp = extract_icmp_dgram,
+    .extract_ttl = extract_ttl_dgram,
     .packet_size = packet_size_dgram,
     .extra_configure = extra_configure_dgram};

--- a/lib/vsock/vsock_raw.c
+++ b/lib/vsock/vsock_raw.c
@@ -46,6 +46,14 @@ struct icmphdr *extract_icmp_raw(void *packet, size_t packet_len, int *icmp_len_
   return (struct icmphdr *)((char *)packet + (ip->ihl * 4));
 }
 
+/* RAW 受信: パケット先頭が IP ヘッダーなので ttl をそのまま読む */
+int extract_ttl_raw(void *packet, const struct msghdr *msg) {
+  (void)msg;
+  if (packet == NULL)
+    return 0;
+  return ((struct iphdr *)packet)->ttl;
+}
+
 int extra_configure_raw(int fd) {
   int hdrincl = 1;
   if (setsockopt(fd, IPPROTO_IP, IP_HDRINCL, &hdrincl, sizeof(hdrincl)) < 0) {
@@ -59,5 +67,6 @@ size_t packet_size_raw(size_t datalen) { return sizeof(t_ip_icmp) + datalen; }
 t_ping_socket_ops Ping_socket_raw_ops = {
     .build_ipheader = build_ipheader_raw,
     .extract_icmp = extract_icmp_raw,
+    .extract_ttl = extract_ttl_raw,
     .packet_size = packet_size_raw,
     .extra_configure = extra_configure_raw};

--- a/src/tool_output.c
+++ b/src/tool_output.c
@@ -32,6 +32,9 @@ void tool_output_reply(const t_ftping_reply *reply, void *ctx) {
 
   printf("%d bytes from %s: icmp_seq=%u", reply->bytes, ip_str, reply->seq);
 
+  if (reply->ttl > 0)
+    printf(" ttl=%d", reply->ttl);
+
   if (reply->triptime_us >= 0)
     printf(" time=%.3f ms", reply->triptime_us / 1000.0);
 

--- a/tests/unit/mock/mock_vsock.cpp
+++ b/tests/unit/mock/mock_vsock.cpp
@@ -22,6 +22,12 @@ static struct icmphdr *mock_extract_icmp(void *packet, size_t packet_len, int *i
   return reinterpret_cast<struct icmphdr *>(packet);
 }
 
+static int mock_extract_ttl(void *packet, const struct msghdr *msg) {
+  (void)packet;
+  (void)msg;
+  return 0;
+}
+
 static size_t mock_packet_size(size_t datalen) {
   g_mock_vsock_state.packet_size_calls++;
   g_mock_vsock_state.last_packet_size_arg = datalen;
@@ -38,6 +44,7 @@ extern "C" {
 t_ping_socket_ops Mock_socket_ops = {
     .build_ipheader = mock_build_ipheader,
     .extract_icmp = mock_extract_icmp,
+    .extract_ttl = mock_extract_ttl,
     .packet_size = mock_packet_size,
     .extra_configure = mock_extra_configure,
 };

--- a/tests/unit/test_vsock_dgram.cpp
+++ b/tests/unit/test_vsock_dgram.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 #include <netinet/in.h>
+#include <string.h>
+#include <sys/socket.h>
 
 extern "C" {
 #include "vsock/vsock.h"
@@ -8,6 +10,7 @@ extern "C" {
 TEST(VsockDgramOpsTest, VtablePointersAreSet) {
   EXPECT_NE(Ping_socket_dgram_ops.build_ipheader, nullptr);
   EXPECT_NE(Ping_socket_dgram_ops.extract_icmp, nullptr);
+  EXPECT_NE(Ping_socket_dgram_ops.extract_ttl, nullptr);
   EXPECT_NE(Ping_socket_dgram_ops.packet_size, nullptr);
   EXPECT_NE(Ping_socket_dgram_ops.extra_configure, nullptr);
 }
@@ -64,6 +67,33 @@ TEST(VsockDgramOpsTest, ExtraConfigureIsNoop) {
 TEST(VsockDgramOpsTest, VtableDiffersFromRaw) {
   EXPECT_NE(Ping_socket_dgram_ops.build_ipheader, Ping_socket_raw_ops.build_ipheader);
   EXPECT_NE(Ping_socket_dgram_ops.extract_icmp, Ping_socket_raw_ops.extract_icmp);
+  EXPECT_NE(Ping_socket_dgram_ops.extract_ttl, Ping_socket_raw_ops.extract_ttl);
   EXPECT_NE(Ping_socket_dgram_ops.packet_size, Ping_socket_raw_ops.packet_size);
   EXPECT_NE(Ping_socket_dgram_ops.extra_configure, Ping_socket_raw_ops.extra_configure);
+}
+
+// extract_ttl_dgram: cmsg を走査して IP_TTL を取り出す
+TEST(VsockDgramOpsTest, ExtractTtlReadsCmsg) {
+  alignas(struct cmsghdr) uint8_t cbuf[CMSG_SPACE(sizeof(int))] = {};
+  struct msghdr msg = {};
+  msg.msg_control = cbuf;
+  msg.msg_controllen = sizeof(cbuf);
+
+  struct cmsghdr *c = CMSG_FIRSTHDR(&msg);
+  c->cmsg_level = IPPROTO_IP;
+  c->cmsg_type = IP_TTL;
+  c->cmsg_len = CMSG_LEN(sizeof(int));
+  int ttl_val = 57;
+  memcpy(CMSG_DATA(c), &ttl_val, sizeof(ttl_val));
+
+  EXPECT_EQ(Ping_socket_dgram_ops.extract_ttl(nullptr, &msg), 57);
+}
+
+TEST(VsockDgramOpsTest, ExtractTtlReturnsZeroWhenNoCmsg) {
+  struct msghdr msg = {};
+  EXPECT_EQ(Ping_socket_dgram_ops.extract_ttl(nullptr, &msg), 0);
+}
+
+TEST(VsockDgramOpsTest, ExtractTtlReturnsZeroForNullMsg) {
+  EXPECT_EQ(Ping_socket_dgram_ops.extract_ttl(nullptr, nullptr), 0);
 }

--- a/tests/unit/test_vsock_raw.cpp
+++ b/tests/unit/test_vsock_raw.cpp
@@ -19,8 +19,23 @@ protected:
 TEST_F(VsockRawOpsTest, VtablePointersAreSet) {
   EXPECT_NE(Ping_socket_raw_ops.build_ipheader, nullptr);
   EXPECT_NE(Ping_socket_raw_ops.extract_icmp, nullptr);
+  EXPECT_NE(Ping_socket_raw_ops.extract_ttl, nullptr);
   EXPECT_NE(Ping_socket_raw_ops.packet_size, nullptr);
   EXPECT_NE(Ping_socket_raw_ops.extra_configure, nullptr);
+}
+
+// extract_ttl_raw: 受信パケット先頭の IP ヘッダーから TTL を取り出す
+TEST_F(VsockRawOpsTest, ExtractTtlReadsIpHeader) {
+  uint8_t buf[sizeof(struct iphdr) + sizeof(struct icmphdr)] = {};
+  struct iphdr *ip = (struct iphdr *)buf;
+  ip->ihl = 5;
+  ip->ttl = 64;
+
+  EXPECT_EQ(Ping_socket_raw_ops.extract_ttl(buf, nullptr), 64);
+}
+
+TEST_F(VsockRawOpsTest, ExtractTtlReturnsZeroForNullPacket) {
+  EXPECT_EQ(Ping_socket_raw_ops.extract_ttl(nullptr, nullptr), 0);
 }
 
 TEST_F(VsockRawOpsTest, PacketSizeIncludesIpHeader) {


### PR DESCRIPTION
## Summary
- ICMP Echo Reply の応答行に `ttl=N` を表示するよう対応 (#37 / CLAUDE.local.md)
- `lib/vsock/` の vtable に `extract_ttl` を追加。RAW は IP ヘッダから、DGRAM は `IP_RECVTTL` cmsg から取得し、socktype 分岐を vsock 内に閉じる
- `lib/ping_loop.c` で `IP_RECVTTL` を setsockopt で有効化し、受信時に `extract_ttl()` を呼んで `t_ftping_reply.ttl` に詰める
- `include/ft_ping/ft_ping.h` の公開 DTO `t_ftping_reply` に `int ttl` を追加
- `src/tool_output.c` で `icmp_seq=` と `time=` の間に ` ttl=N` を出力（0 のときは省略）
- mock vsock とユニットテストを更新

## Test plan
- [x] `ctest` が全通過 (187/187)
- [x] `127.0.0.1` で本家 ping と出力比較: `ttl=64` 一致
- [x] `8.8.8.8` で本家 ping と出力比較: `ttl=116` 一致
- [ ] RAW 経路 (CAP_NET_RAW) と DGRAM 経路の双方で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)