### PR TITLE
update: `-v` への対応を取りやめ

### DIFF
--- a/include/ft_ping/ft_ping.h
+++ b/include/ft_ping/ft_ping.h
@@ -41,7 +41,6 @@ typedef struct ping_config {
   unsigned int opt_useident : 1;
   unsigned int opt_adaptive : 1;
   unsigned int opt_flood_poll : 1;
-  unsigned int opt_verbose : 1;
   unsigned int opt_ptimeofday : 1;
 } t_ping_config;
 

--- a/lib/ping_loop.c
+++ b/lib/ping_loop.c
@@ -280,16 +280,6 @@ int ping_receive_replies(t_ping_session *session, t_ping_receive *received) {
     int is_ours = session->net.socket_state.socktype == SOCK_DGRAM ||
                   (icmp && ntohs(icmp->un.echo.id) == session->net.ident);
 
-    /* verbose モード: ECHOREPLY 以外の ICMP も表示する。
-     * iputils pr_icmph() (ping_common.c) と同じく、type/code を可読形式で出す。 */
-    if (session->config.opt_verbose && icmp && icmp->type != ICMP_ECHOREPLY &&
-        icmp->type != ICMP_ECHO) {
-      char addr_buf[INET_ADDRSTRLEN] = "?";
-      if (from)
-        inet_ntop(AF_INET, &from->sin_addr, addr_buf, sizeof(addr_buf));
-      fprintf(stderr, "From %s: icmp_seq=? Type=%d Code=%d\n", addr_buf, icmp->type, icmp->code);
-    }
-
     if (icmp && is_ours && icmp->type == ICMP_ECHOREPLY) {
       uint16_t seq = ntohs(icmp->un.echo.sequence);
 

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -7,13 +7,10 @@ static void show_usage(void);
 
 int tool_parse_args(int *argc, char ***argv, t_ping_config *config) {
   int ch;
-  while ((ch = getopt(*argc, *argv, "h?AhvDe:t:Q:c:S:s:l:w:")) != EOF) {
+  while ((ch = getopt(*argc, *argv, "h?AhDe:t:Q:c:S:s:l:w:")) != EOF) {
     switch (ch) {
     case 'A': // TODO: -A                 use adaptive ping
       config->opt_adaptive = 1;
-      break;
-    case 'v': // TODO: -v                 verbose output
-      config->opt_verbose = 1;
       break;
     case 'D': // -D                 print timestamps
       config->opt_ptimeofday = 1;
@@ -73,7 +70,6 @@ static void show_usage(void) {
       "  -s <size>          use <size> as number of data bytes to be sent\n"
       "  -S <size>          use <size> as SO_SNDBUF socket option value\n"
       "  -t <ttl>           define time to live\n"
-      "  -v                 verbose output\n"
       "  -w <deadline>      reply wait <deadline> in seconds\n"
       "\n"
       "For more details see https://github.com/GawinGowin/ft_ping.git\n"};

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -27,7 +27,7 @@ int tool_parse_args(int *argc, char ***argv, t_ping_config *config) {
     case 'c': // -c <count>         stop after <count> replies
       config->count = parse_long(optarg, "invalid argument", 0, LONG_MAX, error);
       break;
-    case 'e': // TODO: -e <identifier>    define identifier for ping session,
+    case 'e': // -e <identifier>    define identifier for ping session,
       config->ident = (uint16_t)parse_long(optarg, "invalid argument", 0, 0xFFFF, error);
       config->opt_useident = 1;
       break;
@@ -37,13 +37,13 @@ int tool_parse_args(int *argc, char ***argv, t_ping_config *config) {
     case 's': // -s <size>          use <size> as number of data bytes to be sent
       config->datalen = parse_long(optarg, "invalid argument", 0, INT_MAX, error);
       break;
-    case 'l': // -l <preload>       send <preload> number of packages while waiting replies
+    case 'l': // TODO: -l <preload>       send <preload> number of packages while waiting replies
       config->preload = parse_long(optarg, "invalid argument", 0, 65536, error);
       if (getuid() == 0 && config->preload > 3) {
         error(2, "cannot set preload to value greater than 3: %ld", config->preload);
       }
       break;
-    case 'w': // OK: -w <deadline>      reply wait <deadline> in seconds
+    case 'w': // -w <deadline>      reply wait <deadline> in seconds
       config->deadline_sec = parse_long(optarg, "invalid argument", 0, INT_MAX, error);
       break;
     default:

--- a/src/tool_output.c
+++ b/src/tool_output.c
@@ -17,10 +17,6 @@ void tool_output_reply(const t_ftping_reply *reply, void *ctx) {
     return;
   const t_ping_config *config = (const t_ping_config *)ctx;
 
-  /* 重複かつ非 verbose なら表示しない（cmd/ft_ping parse_reply の条件と同じ） */
-  if (reply->is_duplicate && (!config || !config->opt_verbose))
-    return;
-
   if (config && config->opt_ptimeofday) {
     printf(
         "[%lu.%06lu] ", (unsigned long)reply->recv_time.tv_sec,

--- a/src/tool_output.h
+++ b/src/tool_output.h
@@ -10,7 +10,7 @@
 void tool_output_header(const t_ping_config *config, struct in_addr addr, size_t packet_size);
 
 /* 1 応答ライン。ftping_set_reply_handler に登録するコールバック。
- * ctx は const t_ping_config * を渡す（-D / -v 判定のため）。 */
+ * ctx は const t_ping_config * を渡す（-D 判定のため）。 */
 void tool_output_reply(const t_ftping_reply *reply, void *ctx);
 
 /* 終了時の統計出力 */

--- a/tests/tool/test_tool_getparam.cpp
+++ b/tests/tool/test_tool_getparam.cpp
@@ -53,14 +53,6 @@ TEST_F(ToolParseArgsTest, AdaptiveFlag) {
   EXPECT_EQ(config.opt_adaptive, 1u);
 }
 
-TEST_F(ToolParseArgsTest, VerboseFlag) {
-  int argc;
-  char **argv;
-  make_argv({"ft_ping", "-v", "host"}, &argc, &argv);
-  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
-  EXPECT_EQ(config.opt_verbose, 1u);
-}
-
 TEST_F(ToolParseArgsTest, PrintTimestampFlag) {
   int argc;
   char **argv;
@@ -315,7 +307,7 @@ TEST_F(ToolParseArgsTest, HelpFlagReturns2) {
 TEST_F(ToolParseArgsTest, ArgvAdjustedToRemainingArgs) {
   int argc;
   char **argv;
-  make_argv({"ft_ping", "-v", "-c", "3", "host"}, &argc, &argv);
+  make_argv({"ft_ping", "-c", "3", "host"}, &argc, &argv);
   EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
   EXPECT_EQ(argc, 1);
   EXPECT_STREQ(argv[0], "host");
@@ -333,9 +325,8 @@ TEST_F(ToolParseArgsTest, NoOptionsLeavesHostname) {
 TEST_F(ToolParseArgsTest, MultipleOptionsAndHostname) {
   int argc;
   char **argv;
-  make_argv({"ft_ping", "-v", "-A", "-D", "-t", "128", "-c", "10", "8.8.8.8"}, &argc, &argv);
+  make_argv({"ft_ping", "-A", "-D", "-t", "128", "-c", "10", "8.8.8.8"}, &argc, &argv);
   EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
-  EXPECT_EQ(config.opt_verbose, 1u);
   EXPECT_EQ(config.opt_adaptive, 1u);
   EXPECT_EQ(config.opt_ptimeofday, 1u);
   EXPECT_EQ(config.ttl, 128);
@@ -349,7 +340,7 @@ TEST_F(ToolParseArgsTest, MultipleOptionsAndHostname) {
 TEST_F(ToolParseArgsTest, UnrelatedFieldsUnchanged) {
   int argc;
   char **argv;
-  make_argv({"ft_ping", "-v", "host"}, &argc, &argv);
+  make_argv({"ft_ping", "host"}, &argc, &argv);
   EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
   /* -v 以外はデフォルト値のまま */
   EXPECT_EQ(config.datalen, 56);

--- a/tests/tool/test_tool_output.cpp
+++ b/tests/tool/test_tool_output.cpp
@@ -47,7 +47,6 @@ protected:
   void SetUp() override {
     config.hostname = "localhost";
     config.datalen = 56;
-    config.opt_verbose = 0;
     config.opt_ptimeofday = 0;
 
     inet_aton("127.0.0.1", &reply.from_addr);
@@ -71,18 +70,10 @@ TEST_F(ReplyTest, NoTimingOmitsTimeField) {
   EXPECT_EQ(out, "64 bytes from 127.0.0.1: icmp_seq=1\n");
 }
 
-TEST_F(ReplyTest, DuplicateWithVerbosePrintsDup) {
-  config.opt_verbose = 1;
+TEST_F(ReplyTest, DuplicatePrintsDup) {
   reply.is_duplicate = 1;
   std::string out = capture([&]() { tool_output_reply(&reply, &config); });
   EXPECT_NE(out.find("(DUP!)"), std::string::npos);
-}
-
-TEST_F(ReplyTest, DuplicateWithoutVerboseSilent) {
-  config.opt_verbose = 0;
-  reply.is_duplicate = 1;
-  std::string out = capture([&]() { tool_output_reply(&reply, &config); });
-  EXPECT_EQ(out, "");
 }
 
 TEST_F(ReplyTest, PtimeofdayPrefix) {


### PR DESCRIPTION
このオプションはログ表示をリッチにするもの

本物のpingと比較して、機能を絞って実装している背景からverboseとして何を表示するかの判断の認知的負荷が高いため対応しない。
