### PR TITLE
update: adaptiveモード `-A` を動作させられるようにした

### DIFF
--- a/lib/ping_loop.c
+++ b/lib/ping_loop.c
@@ -4,7 +4,20 @@
 #include <linux/errqueue.h>
 
 #define MIN_INTERVAL_MS 10
+#define MINUSERINTERVAL 200 /* 非root の最小インターバル (ms) — iputils 準拠 */
 #define SCHINT(a) (((a) <= MIN_INTERVAL_MS) ? MIN_INTERVAL_MS : (a))
+
+/* iputils の update_interval() 相当。adaptive モード時、平均 RTT (EWMA) から
+ * 次回送信までの間隔を再計算する。stats->rtt は triptime_us * 8 のスケール。 */
+static void update_interval(t_ping_config *config, uint64_t rtt) {
+  int est_us = rtt ? (int)(rtt / 8) : config->interval_ms * 1000;
+  int new_ms = (est_us + 500) / 1000;
+  if (new_ms < MIN_INTERVAL_MS)
+    new_ms = MIN_INTERVAL_MS;
+  if (getuid() != 0 && new_ms < MINUSERINTERVAL)
+    new_ms = MINUSERINTERVAL;
+  config->interval_ms = new_ms;
+}
 
 /* MSG_ERRQUEUE でエラーキューから 1 件読み出す。
  * IP_RECVERR を有効にしている場合、宛先到達不能等のエラー応答や
@@ -300,9 +313,12 @@ int ping_receive_replies(t_ping_session *session, t_ping_receive *received) {
 
       ping_stats_gather(&session->stats, seq, triptime, is_duplicate);
 
-      /* adaptive モード時: 応答受信時刻を次回送信タイミングの基準として記録 */
-      if (session->config.opt_adaptive)
+      /* adaptive モード時: 応答受信時刻を次回送信タイミングの基準として記録し、
+       * EWMA RTT から interval_ms を動的に再計算する (iputils update_interval 相当)。 */
+      if (session->config.opt_adaptive) {
         session->timer.prev_reply_time = recv_time;
+        update_interval(&session->config, session->stats.rtt);
+      }
 
       if (session->reply_cb) {
         int reply_ttl = session->net.socket_state.ops->extract_ttl(received->iov->iov_base, msg);

--- a/lib/ping_loop.c
+++ b/lib/ping_loop.c
@@ -4,18 +4,17 @@
 #include <linux/errqueue.h>
 
 #define MIN_INTERVAL_MS 10
-#define MINUSERINTERVAL 200 /* 非root の最小インターバル (ms) — iputils 準拠 */
+#define MIN_USER_INTERVAL_MS 2 /* 非root の最小インターバル (ms) — iputils ping.h:67 準拠 */
 #define SCHINT(a) (((a) <= MIN_INTERVAL_MS) ? MIN_INTERVAL_MS : (a))
 
-/* iputils の update_interval() 相当。adaptive モード時、平均 RTT (EWMA) から
- * 次回送信までの間隔を再計算する。stats->rtt は triptime_us * 8 のスケール。 */
+/* iputils の update_interval() (ping_common.c:283) 相当。adaptive モード時、
+ * 平均 RTT (EWMA) から次回送信までの間隔を再計算する。
+ * stats->rtt は triptime_us * 8 のスケール。 */
 static void update_interval(t_ping_config *config, uint64_t rtt) {
   int est_us = rtt ? (int)(rtt / 8) : config->interval_ms * 1000;
   int new_ms = (est_us + 500) / 1000;
-  if (new_ms < MIN_INTERVAL_MS)
-    new_ms = MIN_INTERVAL_MS;
-  if (getuid() != 0 && new_ms < MINUSERINTERVAL)
-    new_ms = MINUSERINTERVAL;
+  if (getuid() != 0 && new_ms < MIN_USER_INTERVAL_MS)
+    new_ms = MIN_USER_INTERVAL_MS;
   config->interval_ms = new_ms;
 }
 

--- a/lib/ping_loop.c
+++ b/lib/ping_loop.c
@@ -196,8 +196,10 @@ int ping_send_one(t_ping_session *session, void *packet, size_t packet_size) {
   t_ping_net_state *net = &session->net;
   t_ping_timer *timer = &session->timer;
 
+  /* count 達成後は十分大きい値を返してメインループの do-while を抜けさせる
+   * (iputils ping_common.c:320-321 と同じ意図)。0 を返すと無限ループになる。 */
   if (config->count > 0 && session->stats.ntransmitted >= config->count)
-    return 0;
+    return 1000;
 
   uint16_t seq = (uint16_t)(session->stats.ntransmitted % UINT16_MAX);
 
@@ -231,6 +233,18 @@ int ping_send_one(t_ping_session *session, void *packet, size_t packet_size) {
   long delta_ms = (now.tv_sec - ref->tv_sec) * 1000 + (now.tv_usec - ref->tv_usec) / 1000;
   if (delta_ms < config->interval_ms)
     return config->interval_ms - (int)delta_ms;
+
+  /* interval_ms == 0 (root + 極小 RTT で update_interval が 0 に丸められたケース) の保護:
+   * 在空中パケットが preload 以上溜まっていて前回送信から MIN_INTERVAL_MS 未経過なら待つ。
+   * iputils の "Case of unlimited flood" (ping_common.c:334-339) 相当で 100pps に制限する。 */
+  if (config->interval_ms == 0) {
+    int in_flight = session->stats.ntransmitted - session->stats.nreceived;
+    int preload = config->preload > 0 ? config->preload : 1;
+    long send_delta_ms = (now.tv_sec - timer->prev_send_time.tv_sec) * 1000 +
+                         (now.tv_usec - timer->prev_send_time.tv_usec) / 1000;
+    if (in_flight >= preload && send_delta_ms < MIN_INTERVAL_MS)
+      return MIN_INTERVAL_MS - (int)send_delta_ms;
+  }
 
   timer->prev_send_time = now;
   t_ipheader_ctx ctx = {

--- a/tests/unit/test_ping_loop.cpp
+++ b/tests/unit/test_ping_loop.cpp
@@ -145,15 +145,17 @@ TEST_F(PingSendOneTest, NtransmittedIncrements) {
   EXPECT_EQ(session.stats.ntransmitted, 1);
 }
 
-/* B-4: count=1 かつ ntransmitted=1 のとき、戻り値が 0（送信しない） */
-TEST_F(PingSendOneTest, CountLimitReachedReturnsZero) {
+/* B-4: count=1 かつ ntransmitted=1 のとき、送信せず正の待ち時間を返す
+ * (iputils ping_common.c:320-321 準拠。0 を返すと do-while (next<=0) が無限ループする) */
+TEST_F(PingSendOneTest, CountLimitReachedDoesNotSend) {
   if (!can_create_socket())
     GTEST_SKIP() << "socket not available";
   session.config.count = 1;
   session.config.interval_ms = 1000;
   session.stats.ntransmitted = 1;
   int ret = ping_send_one(&session, packet, packet_size);
-  EXPECT_EQ(ret, 0);
+  EXPECT_GT(ret, 0);
+  EXPECT_EQ(session.stats.ntransmitted, 1);
 }
 
 /* B-5: count=0（無限）では count による停止が発生しない */


### PR DESCRIPTION
```sh
time ./ft_ping -A -c 1000 localhost
...
--- localhost ping statistics ---
1000 packets transmitted, 1000 received, 0.0% packet loss, time 2000ms
rtt min/avg/max/mdev = 0.009/0.015/0.049/0.005 ms

real    0m2.016s
user    0m0.903s
sys     0m1.113s
```

```sh
time sudo ./ft_ping -A -c 1000 localhost
...
--- localhost ping statistics ---
1000 packets transmitted, 1000 received, 0.0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.010/0.012/0.154/0.005 ms

real    0m0.034s
user    0m0.008s
sys     0m0.018s
```
