### PR TITLE
patch: identifier (`-e`) オプションの挙動を整理

### DIFF
--- a/lib/ping_loop.c
+++ b/lib/ping_loop.c
@@ -430,7 +430,7 @@ int ping_init(t_ping_session *session, char *target) {
   session->stats.tmin = LONG_MAX;
   session->stats.timing = ((size_t)config->datalen >= sizeof(struct timeval)) ? 1 : 0;
 
-  if (ping_socket_select(&net->socket_state, config->opt_useident) < 0) {
+  if (ping_socket_select(&net->socket_state, config->opt_useident && config->ident == 0) < 0) {
     error(0, "socktype: SOCK_RAW\n");
     error(0, "socket: Operation not permitted\n");
     error(2, "=> missing cap_net_raw+p capability or setuid?\n");

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -9,7 +9,7 @@ int tool_parse_args(int *argc, char ***argv, t_ping_config *config) {
   int ch;
   while ((ch = getopt(*argc, *argv, "h?AhDe:t:Q:c:S:s:l:w:")) != EOF) {
     switch (ch) {
-    case 'A': // TODO: -A                 use adaptive ping
+    case 'A': // -A                 use adaptive ping
       config->opt_adaptive = 1;
       break;
     case 'D': // -D                 print timestamps


### PR DESCRIPTION
- ident == 0 の時のみ警告が出るように