### PR TITLE
chore: `-v` オプションを実装

### DIFF
--- a/include/ft_ping/ft_ping.h
+++ b/include/ft_ping/ft_ping.h
@@ -97,6 +97,7 @@ void ftping_set_error_handler(t_ping_session *session, t_ftping_error_cb cb, voi
 void ftping_run(t_ping_session *session);
 t_ftping_summary ftping_get_summary(const t_ping_session *session);
 size_t ftping_get_packet_size(const t_ping_session *session);
+uint16_t ftping_get_ident(const t_ping_session *session);
 struct in_addr ftping_get_target_addr(const t_ping_session *session);
 void ftping_stop(t_ping_session *session);
 void ftping_cleanup(t_ping_session *session);

--- a/include/ft_ping/ft_ping.h
+++ b/include/ft_ping/ft_ping.h
@@ -42,6 +42,7 @@ typedef struct ping_config {
   unsigned int opt_adaptive : 1;
   unsigned int opt_flood_poll : 1;
   unsigned int opt_ptimeofday : 1;
+  unsigned int opt_verbose : 1;
 } t_ping_config;
 
 void error(int status, const char *format, ...);

--- a/include/ft_ping/ft_ping.h
+++ b/include/ft_ping/ft_ping.h
@@ -76,12 +76,24 @@ typedef struct ftping_summary {
 
 typedef void (*t_ftping_reply_cb)(const t_ftping_reply *reply, void *ctx);
 
+/* エラーパケット通知。-v 時に Time Exceeded / Dest Unreach を伝える。 */
+typedef struct ftping_error_event {
+  int icmp_type;
+  int icmp_code;
+  struct in_addr from_addr;
+  uint16_t orig_seq;
+  int orig_seq_valid;
+} t_ftping_error_event;
+
+typedef void (*t_ftping_error_cb)(const t_ftping_error_event *ev, void *ctx);
+
 typedef struct ping_session t_ping_session; /* opaque */
 
 /* ── 公開API ── */
 void ftping_config_init(t_ping_config *config);
 t_ping_session *ftping_init(const t_ping_config *config, const char *target);
 void ftping_set_reply_handler(t_ping_session *session, t_ftping_reply_cb cb, void *ctx);
+void ftping_set_error_handler(t_ping_session *session, t_ftping_error_cb cb, void *ctx);
 void ftping_run(t_ping_session *session);
 t_ftping_summary ftping_get_summary(const t_ping_session *session);
 size_t ftping_get_packet_size(const t_ping_session *session);

--- a/lib/ftping.c
+++ b/lib/ftping.c
@@ -24,6 +24,13 @@ void ftping_set_reply_handler(t_ping_session *session, t_ftping_reply_cb cb, voi
   session->reply_ctx = ctx;
 }
 
+void ftping_set_error_handler(t_ping_session *session, t_ftping_error_cb cb, void *ctx) {
+  if (!session)
+    return;
+  session->error_cb = cb;
+  session->error_ctx = ctx;
+}
+
 void ftping_run(t_ping_session *session) { ping_run(session); }
 
 t_ftping_summary ftping_get_summary(const t_ping_session *session) {

--- a/lib/ftping.c
+++ b/lib/ftping.c
@@ -58,6 +58,8 @@ struct in_addr ftping_get_target_addr(const t_ping_session *session) {
   return session->net.whereto.sin_addr;
 }
 
+uint16_t ftping_get_ident(const t_ping_session *session) { return (session->net.ident); }
+
 void ftping_stop(t_ping_session *session) {
   if (session) {
     session->is_exiting = 1;

--- a/lib/ping_loop.c
+++ b/lib/ping_loop.c
@@ -2,6 +2,8 @@
 
 #include <limits.h>
 #include <linux/errqueue.h>
+#include <netinet/ip.h>
+#include <netinet/ip_icmp.h>
 
 #define MIN_INTERVAL_MS 10
 #define MIN_USER_INTERVAL_MS 2 /* 非root の最小インターバル (ms) — iputils ping.h:67 準拠 */
@@ -353,6 +355,32 @@ int ping_receive_replies(t_ping_session *session, t_ping_receive *received) {
         };
         session->reply_cb(&ev, session->reply_ctx);
       }
+    } else if (icmp && (icmp->type == ICMP_TIME_EXCEEDED || icmp->type == ICMP_DEST_UNREACH)) {
+      if (session->error_cb) {
+        uint16_t orig_seq = 0;
+        int orig_seq_valid = 0;
+        const size_t inner_off = sizeof(struct icmphdr) + sizeof(struct iphdr);
+        if ((size_t)icmp_len >= inner_off + sizeof(struct icmphdr)) {
+          const struct icmphdr *inner = (const struct icmphdr *)((const char *)icmp + inner_off);
+          uint16_t inner_id = ntohs(inner->un.echo.id);
+          if (session->net.socket_state.socktype == SOCK_DGRAM || inner_id == session->net.ident) {
+            orig_seq = ntohs(inner->un.echo.sequence);
+            orig_seq_valid = 1;
+          } else {
+            *received->polling = MSG_DONTWAIT;
+            continue;
+          }
+        }
+        t_ftping_error_event ev = {
+            .icmp_type = icmp->type,
+            .icmp_code = icmp->code,
+            .from_addr = from ? from->sin_addr : (struct in_addr){0},
+            .orig_seq = orig_seq,
+            .orig_seq_valid = orig_seq_valid,
+        };
+        session->error_cb(&ev, session->error_ctx);
+      }
+      /* -v 無しでも継続。プログラムは落とさない。 */
     }
 
     /* 2回目以降は non-blocking で連続吸い出し。

--- a/lib/ping_loop.h
+++ b/lib/ping_loop.h
@@ -41,6 +41,8 @@ typedef struct ping_session {
   volatile int is_exiting; /* ping_stop() がセット */
   t_ftping_reply_cb reply_cb;
   void *reply_ctx;
+  t_ftping_error_cb error_cb;
+  void *error_ctx;
 } t_ping_session;
 
 typedef struct ping_receive {

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -7,8 +7,11 @@ static void show_usage(void);
 
 int tool_parse_args(int *argc, char ***argv, t_ping_config *config) {
   int ch;
-  while ((ch = getopt(*argc, *argv, "h?AhDe:t:Q:c:S:s:l:w:")) != EOF) {
+  while ((ch = getopt(*argc, *argv, "vh?AhDe:t:Q:c:S:s:l:w:")) != EOF) {
     switch (ch) {
+    case 'v': // -v                 verbose output
+      config->opt_verbose = 1;
+      break;
     case 'A': // -A                 use adaptive ping
       config->opt_adaptive = 1;
       break;
@@ -58,6 +61,7 @@ static void show_usage(void) {
       "\nUsage:\n  %s [options] <destination>\n\n"
       "Options:\n"
       "  <destination>      dns name or ip address\n"
+      "  -v                 verbose output\n"
       "  -A                 use adaptive ping\n"
       "  -c <count>         stop after <count> replies\n"
       "  -D                 print timestamps\n"

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -7,11 +7,8 @@ static void show_usage(void);
 
 int tool_parse_args(int *argc, char ***argv, t_ping_config *config) {
   int ch;
-  while ((ch = getopt(*argc, *argv, "vh?AhDe:t:Q:c:S:s:l:w:")) != EOF) {
+  while ((ch = getopt(*argc, *argv, "h?AhDe:t:Q:c:S:s:l:w:v")) != EOF) {
     switch (ch) {
-    case 'v': // -v                 verbose output
-      config->opt_verbose = 1;
-      break;
     case 'A': // -A                 use adaptive ping
       config->opt_adaptive = 1;
       break;
@@ -46,6 +43,9 @@ int tool_parse_args(int *argc, char ***argv, t_ping_config *config) {
     case 'w': // -w <deadline>      reply wait <deadline> in seconds
       config->deadline_sec = parse_long(optarg, "invalid argument", 0, INT_MAX, error);
       break;
+    case 'v': // -v                 verbose output
+      config->opt_verbose = 1;
+      break;
     default:
       show_usage();
       return 2;
@@ -61,7 +61,6 @@ static void show_usage(void) {
       "\nUsage:\n  %s [options] <destination>\n\n"
       "Options:\n"
       "  <destination>      dns name or ip address\n"
-      "  -v                 verbose output\n"
       "  -A                 use adaptive ping\n"
       "  -c <count>         stop after <count> replies\n"
       "  -D                 print timestamps\n"
@@ -74,6 +73,7 @@ static void show_usage(void) {
       "  -s <size>          use <size> as number of data bytes to be sent\n"
       "  -S <size>          use <size> as SO_SNDBUF socket option value\n"
       "  -t <ttl>           define time to live\n"
+      "  -v                 verbose output\n"
       "  -w <deadline>      reply wait <deadline> in seconds\n"
       "\n"
       "For more details see https://github.com/GawinGowin/ft_ping.git\n"};

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
   ftping_set_reply_handler(session, tool_output_reply, &config);
   ftping_set_error_handler(session, tool_output_error, &config);
 
-  tool_output_header(&config, ftping_get_target_addr(session), ftping_get_packet_size(session));
+  tool_output_header(&config, ftping_get_target_addr(session), ftping_get_ident(session));
 
   ftping_run(session);
 

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -24,6 +24,7 @@ int main(int argc, char **argv) {
   tool_setup_signals(session);
 
   ftping_set_reply_handler(session, tool_output_reply, &config);
+  ftping_set_error_handler(session, tool_output_error, &config);
 
   tool_output_header(&config, ftping_get_target_addr(session), ftping_get_packet_size(session));
 

--- a/src/tool_output.c
+++ b/src/tool_output.c
@@ -8,9 +8,10 @@
 void tool_output_header(const t_ping_config *config, struct in_addr addr, size_t packet_size) {
   if (!config)
     return;
+  (void)packet_size;
   printf(
-      "PING %s (%s) %d(%zu) bytes of data.\n", config->hostname ? config->hostname : "",
-      inet_ntoa(addr), config->datalen, packet_size);
+      "PING %s (%s): %d data bytes\n", config->hostname ? config->hostname : "", inet_ntoa(addr),
+      config->datalen);
 }
 
 void tool_output_reply(const t_ftping_reply *reply, void *ctx) {

--- a/src/tool_output.c
+++ b/src/tool_output.c
@@ -48,7 +48,7 @@ void tool_output_finish(const t_ftping_summary *s) {
 
   printf("\n--- %s ping statistics ---\n", s->hostname ? s->hostname : "");
 
-  printf("%d packets transmitted, %d received", s->ntransmitted, s->nreceived);
+  printf("%d packets transmitted, %d packets received", s->ntransmitted, s->nreceived);
 
   if (s->nrepeats)
     printf(", +%ld duplicates", s->nrepeats);
@@ -58,11 +58,11 @@ void tool_output_finish(const t_ftping_summary *s) {
     printf(", +%ld errors", s->nerrors);
 
   if (s->ntransmitted) {
-    double loss = ((double)(s->ntransmitted - s->nreceived) * 100.0) / s->ntransmitted;
-    printf(", %.1f%% packet loss", loss);
+    int loss = (int)(((double)(s->ntransmitted - s->nreceived) * 100.0) / s->ntransmitted);
+    printf(", %d%% packet loss", loss);
   }
 
-  printf(", time %dms\n", s->ntransmitted * s->interval_ms);
+  printf("\n");
 
   if (s->nreceived && s->timing) {
     long total = s->nreceived + s->nrepeats;

--- a/src/tool_output.c
+++ b/src/tool_output.c
@@ -2,6 +2,7 @@
 
 #include <arpa/inet.h>
 #include <limits.h>
+#include <netinet/ip_icmp.h>
 #include <stdio.h>
 
 void tool_output_header(const t_ping_config *config, struct in_addr addr, size_t packet_size) {
@@ -89,4 +90,26 @@ void tool_output_finish(const t_ftping_summary *s) {
         "rtt min/avg/max/mdev = %.3f/%.3f/%.3f/%.3f ms\n", s->tmin / 1000.0, avg_rtt / 1000.0,
         s->tmax / 1000.0, std_dev / 1000.0);
   }
+}
+
+void tool_output_error(const t_ftping_error_event *ev, void *ctx) {
+  if (!ev)
+    return;
+  const t_ping_config *config = (const t_ping_config *)ctx;
+  if (!config || !config->opt_verbose)
+    return;
+
+  char ip_str[INET_ADDRSTRLEN];
+  inet_ntop(AF_INET, &ev->from_addr, ip_str, sizeof(ip_str));
+
+  const char *desc = "ICMP message";
+  if (ev->icmp_type == ICMP_TIME_EXCEEDED)
+    desc = "Time exceeded";
+  else if (ev->icmp_type == ICMP_DEST_UNREACH)
+    desc = "Destination Host Unreachable";
+
+  if (ev->orig_seq_valid)
+    printf("From %s: icmp_seq=%u %s\n", ip_str, ev->orig_seq, desc);
+  else
+    printf("From %s: %s\n", ip_str, desc);
 }

--- a/src/tool_output.c
+++ b/src/tool_output.c
@@ -5,13 +5,17 @@
 #include <netinet/ip_icmp.h>
 #include <stdio.h>
 
-void tool_output_header(const t_ping_config *config, struct in_addr addr, size_t packet_size) {
+void tool_output_header(const t_ping_config *config, struct in_addr addr, uint16_t ident) {
   if (!config)
     return;
-  (void)packet_size;
   printf(
-      "PING %s (%s): %d data bytes\n", config->hostname ? config->hostname : "", inet_ntoa(addr),
+      "PING %s (%s): %d data bytes", config->hostname ? config->hostname : "", inet_ntoa(addr),
       config->datalen);
+  if (config->opt_verbose) {
+    printf(", id 0x%x = %d\n", (int)ident, (int)ident);
+  } else {
+    printf("\n");
+  }
 }
 
 void tool_output_reply(const t_ftping_reply *reply, void *ctx) {

--- a/src/tool_output.c
+++ b/src/tool_output.c
@@ -50,7 +50,7 @@ void tool_output_finish(const t_ftping_summary *s) {
   if (!s)
     return;
 
-  printf("\n--- %s ping statistics ---\n", s->hostname ? s->hostname : "");
+  printf("--- %s ping statistics ---\n", s->hostname ? s->hostname : "");
 
   printf("%d packets transmitted, %d packets received", s->ntransmitted, s->nreceived);
 
@@ -92,7 +92,7 @@ void tool_output_finish(const t_ftping_summary *s) {
     }
 
     printf(
-        "rtt min/avg/max/mdev = %.3f/%.3f/%.3f/%.3f ms\n", s->tmin / 1000.0, avg_rtt / 1000.0,
+        "round-trip min/avg/max/stddev = %.3f/%.3f/%.3f/%.3f ms\n", s->tmin / 1000.0, avg_rtt / 1000.0,
         s->tmax / 1000.0, std_dev / 1000.0);
   }
 }

--- a/src/tool_output.h
+++ b/src/tool_output.h
@@ -16,4 +16,8 @@ void tool_output_reply(const t_ftping_reply *reply, void *ctx);
 /* 終了時の統計出力 */
 void tool_output_finish(const t_ftping_summary *summary);
 
+/* -v 時のエラーパケット表示。ftping_set_error_handler に登録するコールバック。
+ * ctx は const t_ping_config * を渡す（opt_verbose 判定のため）。 */
+void tool_output_error(const t_ftping_error_event *ev, void *ctx);
+
 #endif /* TOOL_OUTPUT_H */

--- a/src/tool_output.h
+++ b/src/tool_output.h
@@ -6,8 +6,8 @@
 #include <netinet/in.h>
 #include <stddef.h>
 
-/* 開始時のヘッダー: "PING %s (%s) %d(%zu) bytes of data." */
-void tool_output_header(const t_ping_config *config, struct in_addr addr, size_t packet_size);
+/* 開始時のヘッダー: "PING localhost (127.0.0.1): 56 data bytes" */
+void tool_output_header(const t_ping_config *config, struct in_addr addr, uint16_t ident);
 
 /* 1 応答ライン。ftping_set_reply_handler に登録するコールバック。
  * ctx は const t_ping_config * を渡す（-D 判定のため）。 */

--- a/tests/tool/test_tool_getparam.cpp
+++ b/tests/tool/test_tool_getparam.cpp
@@ -53,6 +53,14 @@ TEST_F(ToolParseArgsTest, AdaptiveFlag) {
   EXPECT_EQ(config.opt_adaptive, 1u);
 }
 
+TEST_F(ToolParseArgsTest, VerboseFlag) {
+  int argc;
+  char **argv;
+  make_argv({"ft_ping", "-v", "host"}, &argc, &argv);
+  EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.opt_verbose, 1u);
+}
+
 TEST_F(ToolParseArgsTest, PrintTimestampFlag) {
   int argc;
   char **argv;
@@ -335,7 +343,7 @@ TEST_F(ToolParseArgsTest, HelpFlagReturns2) {
 TEST_F(ToolParseArgsTest, ArgvAdjustedToRemainingArgs) {
   int argc;
   char **argv;
-  make_argv({"ft_ping", "-c", "3", "host"}, &argc, &argv);
+  make_argv({"ft_ping", "-v", "-c", "3", "host"}, &argc, &argv);
   EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
   EXPECT_EQ(argc, 1);
   EXPECT_STREQ(argv[0], "host");
@@ -353,8 +361,9 @@ TEST_F(ToolParseArgsTest, NoOptionsLeavesHostname) {
 TEST_F(ToolParseArgsTest, MultipleOptionsAndHostname) {
   int argc;
   char **argv;
-  make_argv({"ft_ping", "-A", "-D", "-t", "128", "-c", "10", "8.8.8.8"}, &argc, &argv);
+  make_argv({"ft_ping", "-v", "-A", "-D", "-t", "128", "-c", "10", "8.8.8.8"}, &argc, &argv);
   EXPECT_EQ(tool_parse_args(&argc, &argv, &config), 0);
+  EXPECT_EQ(config.opt_verbose, 1u);
   EXPECT_EQ(config.opt_adaptive, 1u);
   EXPECT_EQ(config.opt_ptimeofday, 1u);
   EXPECT_EQ(config.ttl, 128);

--- a/tests/tool/test_tool_output.cpp
+++ b/tests/tool/test_tool_output.cpp
@@ -1,5 +1,6 @@
 #include <arpa/inet.h>
 #include <gtest/gtest.h>
+#include <netinet/ip_icmp.h>
 #include <string>
 
 extern "C" {
@@ -29,7 +30,7 @@ TEST_F(HeaderTest, BasicFormat) {
   struct in_addr addr;
   inet_aton("127.0.0.1", &addr);
   std::string out = capture([&]() { tool_output_header(&config, addr, 84); });
-  EXPECT_EQ(out, "PING localhost (127.0.0.1) 56(84) bytes of data.\n");
+  EXPECT_EQ(out, "PING localhost (127.0.0.1): 56 data bytes\n");
 }
 
 TEST_F(HeaderTest, NullConfigDoesNotCrash) {
@@ -115,16 +116,16 @@ TEST_F(FinishTest, BasicCounts) {
   s.ntransmitted = 2;
   s.nreceived = 2;
   std::string out = capture([&]() { tool_output_finish(&s); });
-  EXPECT_NE(out.find("2 packets transmitted, 2 received"), std::string::npos);
-  EXPECT_NE(out.find("0.0% packet loss"), std::string::npos);
-  EXPECT_NE(out.find("time 2000ms"), std::string::npos);
+  EXPECT_NE(out.find("2 packets transmitted, 2 packets received"), std::string::npos);
+  EXPECT_NE(out.find("0% packet loss"), std::string::npos);
+  EXPECT_EQ(out.find("time "), std::string::npos);
 }
 
 TEST_F(FinishTest, FiftyPercentLoss) {
   s.ntransmitted = 4;
   s.nreceived = 2;
   std::string out = capture([&]() { tool_output_finish(&s); });
-  EXPECT_NE(out.find("50.0% packet loss"), std::string::npos);
+  EXPECT_NE(out.find("50% packet loss"), std::string::npos);
 }
 
 TEST_F(FinishTest, DuplicatesShown) {
@@ -182,5 +183,50 @@ TEST_F(FinishTest, RttLineAbsentWhenNoReceived) {
 
 TEST_F(FinishTest, NullSummaryDoesNotCrash) {
   std::string out = capture([&]() { tool_output_finish(nullptr); });
+  EXPECT_EQ(out, "");
+}
+
+/* ─── tool_output_error ──────────────────────────────── */
+
+class ErrorTest : public ::testing::Test {
+protected:
+  t_ping_config config{};
+  t_ftping_error_event ev{};
+  void SetUp() override {
+    config.opt_verbose = 1;
+    inet_aton("10.0.0.1", &ev.from_addr);
+    ev.orig_seq = 3;
+    ev.orig_seq_valid = 1;
+  }
+};
+
+TEST_F(ErrorTest, TimeExceededWithSeq) {
+  ev.icmp_type = ICMP_TIME_EXCEEDED;
+  std::string out = capture([&]() { tool_output_error(&ev, &config); });
+  EXPECT_EQ(out, "From 10.0.0.1: icmp_seq=3 Time exceeded\n");
+}
+
+TEST_F(ErrorTest, DestUnreachWithoutSeq) {
+  ev.icmp_type = ICMP_DEST_UNREACH;
+  ev.orig_seq_valid = 0;
+  std::string out = capture([&]() { tool_output_error(&ev, &config); });
+  EXPECT_EQ(out, "From 10.0.0.1: Destination Host Unreachable\n");
+}
+
+TEST_F(ErrorTest, SuppressedWhenVerboseOff) {
+  config.opt_verbose = 0;
+  ev.icmp_type = ICMP_TIME_EXCEEDED;
+  std::string out = capture([&]() { tool_output_error(&ev, &config); });
+  EXPECT_EQ(out, "");
+}
+
+TEST_F(ErrorTest, NullEvDoesNotCrash) {
+  std::string out = capture([&]() { tool_output_error(nullptr, &config); });
+  EXPECT_EQ(out, "");
+}
+
+TEST_F(ErrorTest, NullCtxSuppressesOutput) {
+  ev.icmp_type = ICMP_TIME_EXCEEDED;
+  std::string out = capture([&]() { tool_output_error(&ev, nullptr); });
   EXPECT_EQ(out, "");
 }

--- a/tests/tool/test_tool_output.cpp
+++ b/tests/tool/test_tool_output.cpp
@@ -189,7 +189,7 @@ TEST_F(FinishTest, RttLineWhenTimingAndReceived) {
   s.tsum = 10000;
   s.tsum2 = 10000.0 * 10000.0;
   std::string out = capture([&]() { tool_output_finish(&s); });
-  EXPECT_NE(out.find("rtt min/avg/max/mdev = 10.000/10.000/10.000/0.000 ms"), std::string::npos);
+  EXPECT_NE(out.find("round-trip min/avg/max/stddev = 10.000/10.000/10.000/0.000 ms"), std::string::npos);
 }
 
 TEST_F(FinishTest, RttLineAbsentWhenTimingOff) {

--- a/tests/tool/test_tool_output.cpp
+++ b/tests/tool/test_tool_output.cpp
@@ -29,14 +29,41 @@ protected:
 TEST_F(HeaderTest, BasicFormat) {
   struct in_addr addr;
   inet_aton("127.0.0.1", &addr);
-  std::string out = capture([&]() { tool_output_header(&config, addr, 84); });
+  std::string out = capture([&]() { tool_output_header(&config, addr, 0); });
   EXPECT_EQ(out, "PING localhost (127.0.0.1): 56 data bytes\n");
 }
 
 TEST_F(HeaderTest, NullConfigDoesNotCrash) {
   struct in_addr addr{};
-  std::string out = capture([&]() { tool_output_header(nullptr, addr, 0); });
+  std::string out = capture([&]() { tool_output_header(nullptr, addr, 100); });
   EXPECT_EQ(out, "");
+}
+
+class HeaderTestVerbose : public ::testing::Test {
+protected:
+  t_ping_config config{};
+  void SetUp() override {
+    config.hostname = "localhost";
+    config.datalen = 56;
+    config.opt_verbose = 1;
+  }
+};
+
+TEST_F(HeaderTestVerbose, BasicFormat) {
+  struct in_addr addr;
+  inet_aton("127.0.0.1", &addr);
+  uint16_t ident = 0xabcd;
+  std::string out = capture([&]() { tool_output_header(&config, addr, ident); });
+  EXPECT_EQ(out, "PING localhost (127.0.0.1): 56 data bytes, id 0xabcd = 43981\n");
+}
+
+TEST_F(HeaderTestVerbose, NullHostname) {
+  struct in_addr addr;
+  inet_aton("8.8.8.8", &addr);
+  config.hostname = nullptr;
+  uint16_t ident = 100;
+  std::string out = capture([&]() { tool_output_header(&config, addr, ident); });
+  EXPECT_EQ(out, "PING  (8.8.8.8): 56 data bytes, id 0x64 = 100\n");
 }
 
 /* ─── tool_output_reply ──────────────────────────────── */

--- a/tests/unit/test_ping_loop.cpp
+++ b/tests/unit/test_ping_loop.cpp
@@ -367,8 +367,7 @@ TEST_F(PingSendOneMockTest, BuildIpHeaderIsInvoked) {
 
   EXPECT_EQ(g_mock_vsock_state.build_ipheader_calls, 1);
   EXPECT_EQ(g_mock_vsock_state.last_seq, 0u);
-  EXPECT_EQ(g_mock_vsock_state.last_datalen,
-            static_cast<size_t>(session.config.datalen));
+  EXPECT_EQ(g_mock_vsock_state.last_datalen, static_cast<size_t>(session.config.datalen));
 }
 
 /* F-2: count に達していたら build_ipheader は呼ばれない */


### PR DESCRIPTION
`-v` オプションの実装はMandatoryのため実装。
それに伴い、ping出力フォーマットが微調整された。

before
```sh
./ft_ping -c 1 localhost | cat -te
PING localhost (127.0.0.1) 56(64) bytes of data.$
64 bytes from 127.0.0.1: icmp_seq=1 ttl=64 time=0.035 ms$
$
--- localhost ping statistics ---$
1 packets transmitted, 1 received, 0.0% packet loss, time 1000ms$
rtt min/avg/max/mdev = 0.035/0.035/0.035/0.000 ms$
```

after
```sh
./ft_ping -c 1 localhost | cat -te
PING localhost (127.0.0.1): 56 data bytes$
64 bytes from 127.0.0.1: icmp_seq=1 ttl=64 time=0.037 ms$
--- localhost ping statistics ---$
1 packets transmitted, 1 packets received, 0% packet loss$
round-trip min/avg/max/stddev = 0.037/0.037/0.037/0.000 ms$
```

---

```sh
ping -c 1 localhost | cat -te
PING localhost (127.0.0.1): 56 data bytes$
64 bytes from 127.0.0.1: icmp_seq=0 ttl=64 time=0.032 ms$
--- localhost ping statistics ---$
1 packets transmitted, 1 packets received, 0% packet loss$
round-trip min/avg/max/stddev = 0.032/0.032/0.032/0.000 ms$
```
