### PR TITLE
chore: 変数の未初期化のエラーを修正

### DIFF
--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -5,7 +5,7 @@
 #include "tool_signal.h"
 
 int main(int argc, char **argv) {
-  t_ping_config config;
+  t_ping_config config = {};
   ftping_config_init(&config);
 
   int err = 0;


### PR DESCRIPTION
以下のエラーを修正

```sh
valgrind ./ft_ping -c 1 localhost
==38738== Memcheck, a memory error detector
==38738== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==38738== Using Valgrind-3.24.0 and LibVEX; rerun with -h for copyright info
==38738== Command: ./ft_ping -c 1 localhost
==38738== 
==38738== Conditional jump or move depends on uninitialised value(s)
==38738==    at 0x10BBD9: ping_init (in /home/saraki/Repo/ft_ping/ft_ping)
==38738==    by 0x10A467: ftping_init (in /home/saraki/Repo/ft_ping/ft_ping)
==38738==    by 0x10D41D: main (in /home/saraki/Repo/ft_ping/ft_ping)
==38738== 
==38738== Conditional jump or move depends on uninitialised value(s)
==38738==    at 0x10BC67: ping_init (in /home/saraki/Repo/ft_ping/ft_ping)
==38738==    by 0x10A467: ftping_init (in /home/saraki/Repo/ft_ping/ft_ping)
==38738==    by 0x10D41D: main (in /home/saraki/Repo/ft_ping/ft_ping)
==38738== 
==38738== Conditional jump or move depends on uninitialised value(s)
==38738==    at 0x10D57A: tool_output_header (in /home/saraki/Repo/ft_ping/ft_ping)
==38738==    by 0x10D4BA: main (in /home/saraki/Repo/ft_ping/ft_ping)
==38738== 
PING localhost (127.0.0.1): 56 data bytes
==38738== Conditional jump or move depends on uninitialised value(s)
==38738==    at 0x10D5E6: tool_output_reply (in /home/saraki/Repo/ft_ping/ft_ping)
==38738==    by 0x10B807: ping_receive_replies (in /home/saraki/Repo/ft_ping/ft_ping)
==38738==    by 0x10AF68: ping_run (in /home/saraki/Repo/ft_ping/ft_ping)
==38738==    by 0x10A514: ftping_run (in /home/saraki/Repo/ft_ping/ft_ping)
==38738==    by 0x10D4C6: main (in /home/saraki/Repo/ft_ping/ft_ping)
==38738== 
64 bytes from 127.0.0.1: icmp_seq=1 ttl=64 time=7.550 ms
--- localhost ping statistics ---
1 packets transmitted, 1 packets received, 0% packet loss
round-trip min/avg/max/stddev = 7.550/7.550/7.550/0.000 ms
==38738== 
==38738== HEAP SUMMARY:
==38738==     in use at exit: 0 bytes in 0 blocks
==38738==   total heap usage: 43 allocs, 43 frees, 39,858 bytes allocated
==38738== 
==38738== All heap blocks were freed -- no leaks are possible
==38738== 
==38738== Use --track-origins=yes to see where uninitialised values come from
==38738== For lists of detected and suppressed errors, rerun with: -s
==38738== ERROR SUMMARY: 4 errors from 4 contexts (suppressed: 0 from 0)
```